### PR TITLE
Add optional chunk vector controls and Meilisearch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project allows you to mirror character cards from multiple sources ([Chub.a
 *   **Offline-First:** Downloads character cards (PNGs + JSON) and caches all gallery images/external assets locally.
 *   **Advanced Search:**
     *   **SQL Search:** Fast filtering by tags, author, tokens, dates, and flags.
-    *   **Semantic Vector Search:** (Optional) Use Ollama + Meilisearch to find characters by "vibe" or description, even if keywords don't match. Supports searching specific chunks of character definitions.
+    *   **Semantic Vector Search:** (Optional) Use Ollama + Meilisearch to find characters by "vibe" or description, even if keywords don't match. Whole-card semantic search is the baseline; chunk vectors are optional if you also want snippet-level semantic matches.
     *   **Boolean Logic:** Full support for `AND`, `OR`, `NOT`, and parenthetical grouping in search queries.
 *   **Integrations:**
     *   **SillyTavern:** One-click push to a running SillyTavern instance. Tracks which cards are already loaded.
@@ -25,7 +25,7 @@ This project allows you to mirror character cards from multiple sources ([Chub.a
 *   **Node.js:** Version 20 or higher.
 *   **pnpm:** Package manager (required for workspace dependencies).
 *   **SQLite:** (Bundled with Node.js drivers, no separate install usually needed).
-*   **Meilisearch (Optional):** Version 1.5+ (Required for advanced/vector search and Character Tavern sync).
+*   **Meilisearch (Optional):** Version 1.40+ recommended (required for advanced/vector search and Character Tavern sync).
 *   **Ollama (Optional):** Required only for semantic vector search embedding generation.
 
 ### Dependencies
@@ -113,10 +113,14 @@ The application relies on a `config.json` file. You can bootstrap this by copyin
         ```json
         "vectorSearch": {
             "enabled": true,
+            "enableChunks": false,
+            "cardsIndex": "cards_vsem",
+            "chunksIndex": "card_chunks",
             "ollamaUrl": "http://127.0.0.1:11434",
             "embedModel": "snowflake-arctic-embed2:latest"
         }
         ```
+        `enableChunks: false` gives you the lower-overhead whole-card semantic index only. Set it to `true` if you also want the optional `card_chunks` index for semantic snippets and chunk reranking.
 
 ### 4. Running the Application
 
@@ -146,7 +150,7 @@ cd /path/to/character-foundry
 # Set up environment
 cd character-archive
 cp .env.example .env
-mkdir -p static meili-data
+mkdir -p static data.ms dumps snapshots
 touch cards.db
 
 # Start services
@@ -157,6 +161,8 @@ Access the application:
 *   **Frontend:** http://localhost:3177
 *   **Backend API:** http://localhost:6969
 *   **Meilisearch:** http://localhost:7700
+
+The shipped Compose stack currently pins Meilisearch to `v1.40.0`, caps it at `32 GiB` RAM, and sets `MEILI_MAX_INDEXING_MEMORY=24GiB` to avoid the runaway-memory behavior seen in earlier uncapped deployments.
 
 For detailed Docker configuration, see [docker/README.md](docker/README.md).
 
@@ -221,13 +227,21 @@ To ensure your archive is truly offline:
     ```bash
     ollama pull snowflake-arctic-embed2
     ```
-3.  Enable `vectorSearch` in `config.json` and restart the server.
-4.  **Important:** You must populate the embeddings index:
+3.  Enable `vectorSearch` in `config.json` and choose whether chunk vectors are enabled:
+    *   `enableChunks: false` = lower footprint, whole-card semantic search only.
+    *   `enableChunks: true` = builds both `cards_vsem` and `card_chunks`, enabling semantic snippets/chunk reranking.
+4.  Restart the server.
+5.  **Important:** You must populate the embeddings index:
     ```bash
     pnpm vector:flush
     pnpm vector:backfill
     ```
     *This process reads all your cards, generates embeddings via Ollama, and uploads them to Meilisearch. It may take a long time.*
+    *`pnpm vector:backfill` now honors `vectorSearch.enableChunks`. If chunks are disabled, it will not recreate `card_chunks`.*
+6.  If you only want to remove chunk vectors while keeping whole-card vectors, run:
+    ```bash
+    pnpm vector:flush -- --chunks-only
+    ```
 
 ### Maintenance Scripts
 *   `pnpm update-metadata`: Refreshes metadata for all local cards from their JSON files.
@@ -259,6 +273,8 @@ pnpm dev 2>&1 | grep '\[SYNC\]'
     Refreshing Character Tavern cards is not supported individually (only bulk sync). The UI will now warn you instead of crashing.
 *   **Meilisearch Errors:**
     If searches fail, ensure Meilisearch is running. If you recently changed schema, run `pnpm sync:search`.
+*   **`card_chunks` Missing:**
+    If `vectorSearch.enableChunks` is `false`, a missing `card_chunks` index is expected. Whole-card vector search still works; re-enable chunks and rerun `pnpm vector:backfill` only if you want semantic snippets/chunk reranking back.
 *   **"Missing Config":**
     If the app crashes complaining about config, ensure `config.json` exists and contains valid JSON. Validate your API keys.
 

--- a/backend/controllers/ConfigController.js
+++ b/backend/controllers/ConfigController.js
@@ -3,7 +3,13 @@ import { saveConfig } from '../../config.js';
 import { appConfig } from '../services/ConfigState.js';
 import { sillyTavernService } from '../services/SillyTavernService.js';
 import { schedulerService } from '../services/SchedulerService.js';
-import { configureSearchIndex, configureVectorSearch, isSearchIndexEnabled, drainSearchIndexQueue } from '../services/search-index.js';
+import {
+    configureSearchIndex,
+    configureVectorSearch,
+    isSearchIndexEnabled,
+    drainSearchIndexQueue,
+    purgeVectorChunkArtifacts
+} from '../services/search-index.js';
 import { logger } from '../utils/logger.js';
 
 const log = logger.scoped('CONFIG');
@@ -15,6 +21,7 @@ class ConfigController {
 
     setConfig = async (req, res) => {
         try {
+            const chunksWereEnabled = appConfig?.vectorSearch?.enableChunks !== false;
             const newConfig = { ...appConfig, ...req.body };
 
             if (newConfig.use_timeline && !newConfig.apikey) {
@@ -30,6 +37,9 @@ class ConfigController {
 
             configureSearchIndex(appConfig.meilisearch);
             configureVectorSearch(appConfig.vectorSearch || {});
+            if (chunksWereEnabled && appConfig?.vectorSearch?.enableChunks === false) {
+                await purgeVectorChunkArtifacts();
+            }
 
             schedulerService.startSearchIndexScheduler();
             if (isSearchIndexEnabled()) {

--- a/backend/controllers/SyncController.js
+++ b/backend/controllers/SyncController.js
@@ -8,6 +8,8 @@ import { getDatabase } from '../database.js';
 import { logger } from '../utils/logger.js';
 import { appConfig } from '../services/ConfigState.js';
 import { drainSearchIndexQueue } from '../services/search-index.js';
+import { scheduleVectorBackfill } from '../services/VectorBackfillService.js';
+import { scheduleOptimization } from '../services/PngOptimizationService.js';
 
 const log = logger.scoped('SYNC');
 
@@ -73,6 +75,8 @@ class SyncController {
             res.end();
         } finally {
             lockService.setSyncInProgress(false);
+            scheduleVectorBackfill('manual-sync');
+            scheduleOptimization('chub-sync');
         }
     }
 
@@ -115,6 +119,8 @@ class SyncController {
             res.end();
         } finally {
             lockService.setCtSyncInProgress(false);
+            scheduleVectorBackfill('ct-sync');
+            scheduleOptimization('ct-sync');
         }
     }
 
@@ -151,6 +157,8 @@ class SyncController {
             res.end();
         } finally {
             lockService.setSyncInProgress(false);
+            scheduleVectorBackfill('wyvern-sync');
+            scheduleOptimization('wyvern-sync');
         }
     }
 
@@ -187,6 +195,7 @@ class SyncController {
             res.end();
         } finally {
             lockService.setSyncInProgress(false);
+            scheduleVectorBackfill('risuai-sync');
         }
     }
 

--- a/backend/db/schema.js
+++ b/backend/db/schema.js
@@ -105,6 +105,25 @@ export function ensureSchema(db) {
         CREATE INDEX IF NOT EXISTS idx_search_index_queue_card ON search_index_queue(cardId);
         CREATE INDEX IF NOT EXISTS idx_search_index_queue_action ON search_index_queue(action);
 
+        CREATE TABLE IF NOT EXISTS vector_index_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cardId TEXT NOT NULL,
+            action TEXT NOT NULL CHECK(action IN ('upsert','delete')),
+            queuedAt TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_vector_index_queue_card ON vector_index_queue(cardId);
+        CREATE INDEX IF NOT EXISTS idx_vector_index_queue_action ON vector_index_queue(action);
+
+        CREATE TABLE IF NOT EXISTS png_optimization_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cardId INTEGER NOT NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(cardId)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_png_optimization_queue_card ON png_optimization_queue(cardId);
+
         CREATE TRIGGER IF NOT EXISTS trg_cards_after_insert_search_queue
         AFTER INSERT ON cards
         BEGIN
@@ -121,6 +140,38 @@ export function ensureSchema(db) {
         AFTER DELETE ON cards
         BEGIN
             INSERT INTO search_index_queue(cardId, action) VALUES (OLD.id, 'delete');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_cards_after_insert_vector_queue
+        AFTER INSERT ON cards
+        BEGIN
+            INSERT INTO vector_index_queue(cardId, action) VALUES (NEW.id, 'upsert');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_cards_after_update_vector_queue
+        AFTER UPDATE ON cards
+        BEGIN
+            INSERT INTO vector_index_queue(cardId, action) VALUES (NEW.id, 'upsert');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_cards_after_delete_vector_queue
+        AFTER DELETE ON cards
+        BEGIN
+            INSERT INTO vector_index_queue(cardId, action) VALUES (OLD.id, 'delete');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_cards_after_insert_png_opt_queue
+        AFTER INSERT ON cards
+        WHEN NEW.source != 'risuai'
+        BEGIN
+            INSERT OR IGNORE INTO png_optimization_queue(cardId) VALUES (NEW.id);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_cards_after_update_png_opt_queue
+        AFTER UPDATE ON cards
+        WHEN NEW.source != 'risuai'
+        BEGIN
+            INSERT OR IGNORE INTO png_optimization_queue(cardId) VALUES (NEW.id);
         END;
 
         CREATE TABLE IF NOT EXISTS card_embedding_meta (

--- a/backend/services/PngOptimizationService.js
+++ b/backend/services/PngOptimizationService.js
@@ -1,0 +1,156 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logger } from '../utils/logger.js';
+import { appConfig } from './ConfigState.js';
+import { lockService } from './LockService.js';
+import { getDatabase } from '../database.js';
+
+const log = logger.scoped('PNG-OPT');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.join(__dirname, '../..');
+const scriptPath = path.join(projectRoot, 'scripts', 'optimize-pngs.js');
+
+let scheduleTimer = null;
+let optimizeInFlight = false;
+let rerunRequested = false;
+let pendingReason = null;
+
+function resolveDelayMs() {
+    const configured = Number(
+        appConfig?.pngOptimization?.postSyncDelaySeconds
+        || process.env.PNG_OPT_POST_SYNC_DELAY_SECONDS
+        || 60
+    );
+    const boundedSeconds = Math.max(5, Math.min(3600, Number.isFinite(configured) ? configured : 60));
+    return boundedSeconds * 1000;
+}
+
+function optimizationEnabled() {
+    return appConfig?.pngOptimization?.enabled !== false;
+}
+
+function hasSyncInProgress() {
+    return lockService.isSyncInProgress() || lockService.isCtSyncInProgress();
+}
+
+function startOptimization(reason) {
+    if (!optimizationEnabled()) {
+        return;
+    }
+    if (hasSyncInProgress()) {
+        scheduleOptimization(reason);
+        return;
+    }
+
+    let queued = 0;
+    try {
+        const db = getDatabase();
+        const row = db.prepare('SELECT COUNT(*) AS count FROM png_optimization_queue').get();
+        queued = row?.count || 0;
+        if (queued <= 0) {
+            log.info('PNG optimization queue empty; skipping run');
+            return;
+        }
+    } catch (error) {
+        log.warn('Unable to check PNG optimization queue size; proceeding', error);
+    }
+
+    if (optimizeInFlight) {
+        rerunRequested = true;
+        pendingReason = reason;
+        log.info(`PNG optimization already running; queued rerun [reason=${reason}]`);
+        return;
+    }
+
+    optimizeInFlight = true;
+    rerunRequested = false;
+    log.info(`PNG optimization starting [reason=${reason}, queued=${queued}]`);
+
+    const env = { ...process.env };
+
+    const batchLimit = Number(
+        appConfig?.pngOptimization?.batchSize
+        || process.env.PNG_OPT_BATCH_SIZE
+        || 200
+    );
+    const safeBatchLimit = Number.isFinite(batchLimit) && batchLimit > 0 ? Math.floor(batchLimit) : 200;
+
+    let queueRows = [];
+    try {
+        const db = getDatabase();
+        queueRows = db.prepare(
+            'SELECT q.id, q.cardId FROM png_optimization_queue q ORDER BY q.id LIMIT ?'
+        ).all(safeBatchLimit);
+    } catch (error) {
+        log.error('Failed to read PNG optimization queue rows', error);
+    }
+
+    if (!queueRows.length) {
+        log.info('PNG optimization queue empty; skipping run');
+        optimizeInFlight = false;
+        return;
+    }
+
+    const cardIds = queueRows.map(row => String(row.cardId));
+    const queueRowIds = queueRows.map(row => row.id);
+
+    env.LCR_OPTIMIZE_IDS = cardIds.join(',');
+    env.LCR_OPTIMIZE_QUEUE_IDS = queueRowIds.join(',');
+    env.LCR_OPTIMIZE_BATCH = String(safeBatchLimit);
+
+    if (appConfig?.pngOptimization?.maxMegapixels) {
+        env.LCR_OPTIMIZE_MAX_MP = String(appConfig.pngOptimization.maxMegapixels);
+    }
+    if (appConfig?.pngOptimization?.compressionLevel != null) {
+        env.LCR_OPTIMIZE_COMPRESSION = String(appConfig.pngOptimization.compressionLevel);
+    }
+
+    const child = spawn(process.execPath, [scriptPath], {
+        cwd: projectRoot,
+        env,
+        stdio: 'inherit'
+    });
+
+    child.on('exit', (code, signal) => {
+        optimizeInFlight = false;
+        if (code === 0) {
+            log.info('PNG optimization completed');
+        } else {
+            log.warn(`PNG optimization exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
+        }
+        if (rerunRequested) {
+            const reasonToUse = pendingReason || 'queued';
+            rerunRequested = false;
+            scheduleOptimization(reasonToUse, resolveDelayMs());
+        }
+    });
+
+    child.on('error', (error) => {
+        optimizeInFlight = false;
+        log.error('PNG optimization failed to start', error);
+        if (rerunRequested) {
+            const reasonToUse = pendingReason || 'queued';
+            rerunRequested = false;
+            scheduleOptimization(reasonToUse, resolveDelayMs());
+        }
+    });
+}
+
+export function scheduleOptimization(reason = 'sync-complete', delayMs = null) {
+    if (!optimizationEnabled()) {
+        return;
+    }
+    pendingReason = reason;
+    if (scheduleTimer) {
+        clearTimeout(scheduleTimer);
+    }
+    const delay = Number.isFinite(delayMs) ? delayMs : resolveDelayMs();
+    scheduleTimer = setTimeout(() => {
+        scheduleTimer = null;
+        startOptimization(pendingReason || reason);
+    }, delay);
+    log.info(`PNG optimization scheduled in ${Math.round(delay / 1000)}s [reason=${reason}]`);
+}

--- a/backend/services/SchedulerService.js
+++ b/backend/services/SchedulerService.js
@@ -5,6 +5,8 @@ import { syncCharacterTavern } from './scrapers/CtScraper.js';
 import { drainSearchIndexQueue, isSearchIndexEnabled } from './search-index.js';
 import { computeDailySnapshot } from './MetricsService.js';
 import { lockService } from './LockService.js';
+import { scheduleVectorBackfill } from './VectorBackfillService.js';
+import { scheduleOptimization } from './PngOptimizationService.js';
 import { getDatabase } from '../database.js';
 import { logger } from '../utils/logger.js';
 
@@ -55,6 +57,8 @@ class SchedulerService {
                 });
                 console.log('[INFO] Auto-update complete');
                 await drainSearchIndexQueue('auto-update');
+                scheduleVectorBackfill('auto-update');
+                scheduleOptimization('auto-update');
             } catch (error) {
                 log.error('Auto-update failed', error);
             } finally {
@@ -95,6 +99,8 @@ class SchedulerService {
                 });
                 console.log('[INFO] Character Tavern auto-sync complete');
                 await drainSearchIndexQueue('ct-auto-sync');
+                scheduleVectorBackfill('ct-auto-sync');
+                scheduleOptimization('ct-auto-sync');
             } catch (error) {
                 log.error('Character Tavern auto-sync failed', error);
             } finally {

--- a/backend/services/SchedulerService.js
+++ b/backend/services/SchedulerService.js
@@ -124,6 +124,9 @@ class SchedulerService {
         }
 
         this.searchIndexQueueTimer = setInterval(() => {
+            if (lockService.isSyncInProgress() || lockService.isCtSyncInProgress()) {
+                return;
+            }
             drainSearchIndexQueue('interval');
         }, this.SEARCH_INDEX_QUEUE_INTERVAL_MS);
     }

--- a/backend/services/VectorBackfillService.js
+++ b/backend/services/VectorBackfillService.js
@@ -1,0 +1,158 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logger } from '../utils/logger.js';
+import { appConfig } from './ConfigState.js';
+import { lockService } from './LockService.js';
+import { getDatabase } from '../database.js';
+
+const log = logger.scoped('VECTOR-BACKFILL');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.join(__dirname, '../..');
+const scriptPath = path.join(projectRoot, 'scripts', 'etl_cards_vector_search.js');
+
+let scheduleTimer = null;
+let backfillInFlight = false;
+let rerunRequested = false;
+let pendingReason = null;
+
+function resolveDelayMs() {
+    const configured = Number(appConfig?.vectorSearch?.postSyncDelaySeconds || process.env.VECTOR_POST_SYNC_DELAY_SECONDS || 30);
+    const boundedSeconds = Math.max(5, Math.min(3600, Number.isFinite(configured) ? configured : 30));
+    return boundedSeconds * 1000;
+}
+
+function vectorEnabled() {
+    return appConfig?.vectorSearch?.enabled === true && appConfig?.meilisearch?.enabled === true;
+}
+
+function hasSyncInProgress() {
+    return lockService.isSyncInProgress() || lockService.isCtSyncInProgress();
+}
+
+function startBackfill(reason) {
+    if (!vectorEnabled()) {
+        return;
+    }
+    if (hasSyncInProgress()) {
+        scheduleVectorBackfill(reason);
+        return;
+    }
+    try {
+        const db = getDatabase();
+        const row = db.prepare('SELECT COUNT(*) AS count FROM vector_index_queue').get();
+        const queued = row?.count || 0;
+        if (queued <= 0) {
+            log.info('Vector queue empty; skipping backfill run');
+            return;
+        }
+    } catch (error) {
+        log.warn('Unable to check vector queue size; proceeding with backfill', error);
+    }
+    if (backfillInFlight) {
+        rerunRequested = true;
+        pendingReason = reason;
+        log.info(`Vector backfill already running; queued rerun [reason=${reason}]`);
+        return;
+    }
+
+    backfillInFlight = true;
+    rerunRequested = false;
+    log.info(`Vector backfill starting [reason=${reason}]`);
+
+    const env = {
+        ...process.env
+    };
+    const queueBatch = Number(appConfig?.vectorSearch?.postSyncQueueBatch || process.env.VECTOR_POST_SYNC_QUEUE_BATCH || 0);
+    const batchLimit = Number.isFinite(queueBatch) && queueBatch > 0 ? Math.floor(queueBatch) : 500;
+    let queueRows = [];
+    try {
+        const db = getDatabase();
+        queueRows = db.prepare('SELECT id, cardId, action FROM vector_index_queue ORDER BY id LIMIT ?').all(batchLimit);
+    } catch (error) {
+        log.error('Failed to read vector queue rows', error);
+    }
+
+    if (!queueRows.length) {
+        log.info('Vector queue empty; skipping backfill run');
+        backfillInFlight = false;
+        return;
+    }
+
+    const actionMap = new Map();
+    for (const row of queueRows) {
+        const cardId = String(row.cardId);
+        const action = row.action === 'delete' ? 'delete' : 'upsert';
+        const existing = actionMap.get(cardId);
+        if (!existing || action === 'delete') {
+            actionMap.set(cardId, action);
+        }
+    }
+
+    const deleteIds = [];
+    const upsertIds = [];
+    actionMap.forEach((action, cardId) => {
+        if (action === 'delete') {
+            deleteIds.push(cardId);
+        } else {
+            upsertIds.push(cardId);
+        }
+    });
+
+    const queueRowIds = queueRows.map(row => row.id);
+    if (upsertIds.length) {
+        env.LCR_VECTOR_IDS = upsertIds.join(',');
+    }
+    if (deleteIds.length) {
+        env.LCR_VECTOR_DELETE_IDS = deleteIds.join(',');
+    }
+    env.LCR_VECTOR_QUEUE_IDS = queueRowIds.join(',');
+
+    const child = spawn(process.execPath, [scriptPath], {
+        cwd: projectRoot,
+        env,
+        stdio: 'inherit'
+    });
+
+    child.on('exit', (code, signal) => {
+        backfillInFlight = false;
+        if (code === 0) {
+            log.info('Vector backfill completed');
+        } else {
+            log.warn(`Vector backfill exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
+        }
+        if (rerunRequested) {
+            const reasonToUse = pendingReason || 'queued';
+            rerunRequested = false;
+            scheduleVectorBackfill(reasonToUse, resolveDelayMs());
+        }
+    });
+
+    child.on('error', (error) => {
+        backfillInFlight = false;
+        log.error('Vector backfill failed to start', error);
+        if (rerunRequested) {
+            const reasonToUse = pendingReason || 'queued';
+            rerunRequested = false;
+            scheduleVectorBackfill(reasonToUse, resolveDelayMs());
+        }
+    });
+}
+
+export function scheduleVectorBackfill(reason = 'sync-complete', delayMs = null) {
+    if (!vectorEnabled()) {
+        return;
+    }
+    pendingReason = reason;
+    if (scheduleTimer) {
+        clearTimeout(scheduleTimer);
+    }
+    const delay = Number.isFinite(delayMs) ? delayMs : resolveDelayMs();
+    scheduleTimer = setTimeout(() => {
+        scheduleTimer = null;
+        startBackfill(pendingReason || reason);
+    }, delay);
+    log.info(`Vector backfill scheduled in ${Math.round(delay / 1000)}s [reason=${reason}]`);
+}

--- a/backend/services/search-index.js
+++ b/backend/services/search-index.js
@@ -102,6 +102,7 @@ const MS_IN_DAY = 24 * 60 * 60 * 1000;
 
 let vectorSearchConfig = {
     enabled: false,
+    enableChunks: true,
     cardsIndex: 'cards_vsem',
     chunksIndex: 'card_chunks',
     embedModel: DEFAULT_EMBED_MODEL,
@@ -118,6 +119,14 @@ let vectorSearchConfig = {
 let vectorIndexReady = false;
 let vectorIndexSetupPromise = null;
 let chunkIndexHasDocs = true;
+
+function chunksAreEnabled(config = vectorSearchConfig) {
+    return config?.enableChunks !== false && Boolean((config?.chunksIndex || '').trim());
+}
+
+function getConfiguredChunkIndexUid(config = vectorSearchConfig) {
+    return chunksAreEnabled(config) ? (config?.chunksIndex || '').trim() : '';
+}
 
 export function configureSearchIndex(config = {}) {
     if (!config || config.enabled !== true) {
@@ -152,6 +161,7 @@ export function configureSearchIndex(config = {}) {
 export function configureVectorSearch(config = {}) {
     const sanitized = { ...vectorSearchConfig };
     if (typeof config.enabled === 'boolean') sanitized.enabled = config.enabled;
+    if (typeof config.enableChunks === 'boolean') sanitized.enableChunks = config.enableChunks;
     if (typeof config.cardsIndex === 'string' && config.cardsIndex.trim()) {
         sanitized.cardsIndex = config.cardsIndex.trim();
     }
@@ -191,8 +201,13 @@ export function configureVectorSearch(config = {}) {
 
     vectorSearchConfig = sanitized;
     vectorIndexReady = false;
+    chunkIndexHasDocs = chunksAreEnabled(sanitized);
     if (vectorSearchConfig.enabled) {
-        log.info(`Vector search configured (cards=${vectorSearchConfig.cardsIndex}, chunks=${vectorSearchConfig.chunksIndex})`);
+        if (chunksAreEnabled(vectorSearchConfig)) {
+            log.info(`Vector search configured (cards=${vectorSearchConfig.cardsIndex}, chunks=${vectorSearchConfig.chunksIndex})`);
+        } else {
+            log.info(`Vector search configured (cards=${vectorSearchConfig.cardsIndex}, chunks=disabled)`);
+        }
     }
     return vectorSearchConfig.enabled;
 }
@@ -218,6 +233,103 @@ function ensureMeiliEnabled() {
         throw new Error('Meilisearch is not enabled');
     }
     return meiliIndex;
+}
+
+export async function purgeVectorChunkArtifacts({ deleteIndex = true } = {}) {
+    const database = getDatabase();
+    if (!database) {
+        throw new Error('Database is not initialized');
+    }
+
+    const chunksIndexUid = (vectorSearchConfig.chunksIndex || '').trim();
+    let deletedIndex = false;
+    if (deleteIndex && meiliClient && chunksIndexUid) {
+        try {
+            const task = await meiliClient.deleteIndex(chunksIndexUid);
+            await waitForIndexTask(null, task, { label: `Delete chunk index (${chunksIndexUid})` });
+            deletedIndex = true;
+        } catch (error) {
+            const message = String(error?.message || '');
+            if (!message.includes('index_not_found') && !message.includes('not found')) {
+                throw error;
+            }
+            log.info(`Chunk index "${chunksIndexUid}" already absent`);
+        }
+    }
+
+    const chunkMapResult = database.prepare('DELETE FROM card_chunk_map').run();
+    const chunkMetaResult = database.prepare('DELETE FROM card_embedding_meta WHERE chunk_index >= 0').run();
+
+    chunkIndexHasDocs = false;
+    resetVectorIndexState('chunk-artifacts-purged');
+
+    const summary = {
+        deletedIndex,
+        clearedChunkMapRows: chunkMapResult.changes || 0,
+        clearedChunkMetaRows: chunkMetaResult.changes || 0
+    };
+    log.info('Purged vector chunk artifacts', summary);
+    return summary;
+}
+
+export async function ensureVectorEmbedders() {
+    if (!vectorSearchConfig.enabled) {
+        return false;
+    }
+    if (!meiliClient) {
+        log.warn('Cannot ensure vector embedders: Meilisearch client is not configured');
+        return false;
+    }
+    if (!vectorSearchConfig.embedderName) {
+        log.warn('Cannot ensure vector embedders: embedderName is not configured');
+        return false;
+    }
+    const dimensions = Number(vectorSearchConfig.embedDimensions);
+    if (!Number.isFinite(dimensions) || dimensions <= 0) {
+        log.warn('Cannot ensure vector embedders: embedDimensions is not configured');
+        return false;
+    }
+    const indexUids = [vectorSearchConfig.cardsIndex, getConfiguredChunkIndexUid()]
+        .map(uid => (uid || '').trim())
+        .filter(Boolean);
+    if (!indexUids.length) {
+        log.warn('Cannot ensure vector embedders: no vector indexes configured');
+        return false;
+    }
+
+    for (const uid of indexUids) {
+        const index = await ensureVectorIndex(uid, 'id');
+        let settings = {};
+        try {
+            settings = await index.getSettings();
+        } catch (error) {
+            log.warn(`Failed to read settings for index "${uid}"`, error);
+        }
+        const embedders = settings?.embedders || {};
+        const currentEmbedder = embedders[vectorSearchConfig.embedderName];
+        const currentDimensions = Number(currentEmbedder?.dimensions);
+        if (currentEmbedder && Number.isFinite(currentDimensions) && currentDimensions === dimensions) {
+            continue;
+        }
+        const pending = await hasPendingSettingsUpdate(uid);
+        if (pending) {
+            log.warn(`Embedder settings update already pending for index "${uid}"`);
+            continue;
+        }
+        const task = await index.updateSettings({
+            embedders: {
+                ...embedders,
+                [vectorSearchConfig.embedderName]: {
+                    source: 'userProvided',
+                    dimensions
+                }
+            }
+        });
+        await waitForIndexTask(index, task, { label: `Meili settings (${uid})` });
+        log.info(`Updated embedder settings for index "${uid}" (${vectorSearchConfig.embedderName}, ${dimensions})`);
+    }
+
+    return true;
 }
 
 async function applyDefaultSettings() {
@@ -929,6 +1041,40 @@ function ensureVectorClient() {
     }
 }
 
+function isMissingEmbedderError(error) {
+    const message = String(error?.message || error || '');
+    return message.includes('Cannot find embedder');
+}
+
+function resetVectorIndexState(reason = '') {
+    vectorIndexReady = false;
+    vectorIndexSetupPromise = null;
+    if (reason) {
+        log.warn(`Vector index state reset (${reason})`);
+    }
+}
+
+async function hasPendingSettingsUpdate(indexUid) {
+    if (!meiliClient?.tasks || typeof meiliClient.tasks.getTasks !== 'function') {
+        return false;
+    }
+    const uid = (indexUid || '').trim();
+    if (!uid) return false;
+    try {
+        const tasks = await meiliClient.tasks.getTasks({
+            indexUids: [uid],
+            types: ['settingsUpdate'],
+            statuses: ['enqueued', 'processing'],
+            limit: 1
+        });
+        const results = Array.isArray(tasks?.results) ? tasks.results : [];
+        return results.length > 0;
+    } catch (error) {
+        log.warn('Failed to check Meilisearch task queue', error);
+        return false;
+    }
+}
+
 async function fetchQueryEmbedding(text) {
     const trimmed = typeof text === 'string' ? text.trim() : '';
     if (!trimmed) {
@@ -1011,43 +1157,57 @@ function resolveEmbedDimensions(observedLength = null) {
     return null;
 }
 
-async function waitForIndexTask(index, task) {
-    if (!task) return;
+async function waitForIndexTask(index, task, { timeoutMs = 60000, allowFallback = true, label = 'Meili task' } = {}) {
+    if (!task) return true;
     const taskUid = task?.taskUid ?? task?.uid;
-    if (!taskUid) return;
-    const waitOpts = { timeOutMs: 60000 };
+    if (!taskUid) return true;
+    const waitOpts = { timeOutMs: timeoutMs };
+    if (meiliClient?.tasks && typeof meiliClient.tasks.getTask === 'function') {
+        const start = Date.now();
+        let lastLog = 0;
+        while (true) {
+            const taskStatus = await meiliClient.tasks.getTask(taskUid);
+            const status = taskStatus?.status || 'unknown';
+            const elapsedSec = Math.floor((Date.now() - start) / 1000);
+            if (Date.now() - lastLog > 5000) {
+                log.info(`${label} ${taskUid} status=${status} elapsed=${elapsedSec}s`);
+                lastLog = Date.now();
+            }
+            if (status !== 'enqueued' && status !== 'processing') {
+                return true;
+            }
+            if (Date.now() - start > timeoutMs) {
+                log.warn(`Timed out waiting for Meilisearch task ${taskUid} (status=${status})`);
+                return false;
+            }
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+    }
     if (index && typeof index.waitForTask === 'function') {
         try {
             await index.waitForTask(taskUid, waitOpts);
-            return;
-        } catch {
+            return true;
+        } catch (error) {
+            if (!allowFallback) {
+                log.warn('Failed waiting for Meilisearch task', error);
+                return false;
+            }
             // fall through to global wait
         }
     }
     if (meiliClient && typeof meiliClient.waitForTask === 'function') {
         try {
             await meiliClient.waitForTask(taskUid, waitOpts);
+            return true;
         } catch (error) {
             log.warn('Failed waiting for Meilisearch task', error);
-        }
-    } else if (meiliClient?.tasks && typeof meiliClient.tasks.getTask === 'function') {
-        const start = Date.now();
-        while (true) {
-            const taskStatus = await meiliClient.tasks.getTask(taskUid);
-            if (!taskStatus || taskStatus.status === 'enqueued' || taskStatus.status === 'processing') {
-                if (Date.now() - start > 60000) {
-                    log.warn(`Timed out waiting for Meilisearch task ${taskUid}`);
-                    break;
-                }
-                await new Promise(resolve => setTimeout(resolve, 500));
-                continue;
-            }
-            break;
+            return false;
         }
     }
+    return true;
 }
 
-async function ensureVectorIndexesReady(observedLength) {
+async function ensureVectorIndexesReady(observedLength, options = {}) {
     if (vectorIndexReady) {
         return;
     }
@@ -1061,6 +1221,9 @@ async function ensureVectorIndexesReady(observedLength) {
     if (!meiliClient) {
         throw new Error('Meilisearch client is not configured');
     }
+    const waitTimeoutMs = Number.isFinite(options.waitTimeoutMs) ? options.waitTimeoutMs : 60000;
+    const allowPending = options.allowPending === true;
+    const allowFallbackWait = options.allowFallbackWait !== false;
     if (vectorIndexSetupPromise) {
         return vectorIndexSetupPromise;
     }
@@ -1072,21 +1235,25 @@ async function ensureVectorIndexesReady(observedLength) {
                 filterables: Array.from(FILTERABLE_FIELDS),
                 distinct: null
             },
-            {
-                uid: vectorSearchConfig.chunksIndex,
-                primaryKey: 'id',
-                filterables: VECTOR_CHUNK_FILTERABLES,
-                distinct: VECTOR_CHUNK_DISTINCT_ATTRIBUTE
-            }
+            ...(chunksAreEnabled()
+                ? [{
+                    uid: vectorSearchConfig.chunksIndex,
+                    primaryKey: 'id',
+                    filterables: VECTOR_CHUNK_FILTERABLES,
+                    distinct: VECTOR_CHUNK_DISTINCT_ATTRIBUTE
+                }]
+                : [])
         ].filter(def => (def.uid || '').trim());
         if (!indexDefinitions.length) {
             throw new Error('Vector indexes are not configured');
         }
         const cardsIndexUid = (vectorSearchConfig.cardsIndex || '').trim();
-        const chunksIndexUid = (vectorSearchConfig.chunksIndex || '').trim();
+        const chunksIndexUid = getConfiguredChunkIndexUid();
 
         let cardsDocs = null;
         let chunksDocs = null;
+        let settingsPending = false;
+        let embedderReady = true;
         for (const definition of indexDefinitions) {
             const { uid, primaryKey, filterables, distinct } = definition;
             const index = await ensureVectorIndex(uid, primaryKey);
@@ -1106,6 +1273,7 @@ async function ensureVectorIndexesReady(observedLength) {
                     throw new Error(`Embedder "${vectorSearchConfig.embedderName}" on index "${uid}" expects dimension ${currentDimensions}, but the current model produced ${dimensions}. Recreate the index or update config.vectorSearch.embedDimensions.`);
                 }
             } else {
+                embedderReady = false;
                 pendingSettings.embedders = {
                     ...embedders,
                     [vectorSearchConfig.embedderName]: {
@@ -1131,9 +1299,29 @@ async function ensureVectorIndexesReady(observedLength) {
             }
 
             if (Object.keys(pendingSettings).length > 0) {
+                const alreadyPending = await hasPendingSettingsUpdate(uid);
+                if (alreadyPending) {
+                    settingsPending = true;
+                    log.warn(`Settings update already pending for index "${uid}"`);
+                    continue;
+                }
                 const task = await index.updateSettings(pendingSettings);
-                await waitForIndexTask(index, task);
-                log.info(`Updated settings for index "${uid}" (${Object.keys(pendingSettings).join(', ')})`);
+                let completed = true;
+                if (waitTimeoutMs <= 0) {
+                    completed = false;
+                } else {
+                    completed = await waitForIndexTask(index, task, {
+                        timeoutMs: waitTimeoutMs,
+                        allowFallback: allowFallbackWait,
+                        label: `Meili settings (${uid})`
+                    });
+                }
+                if (completed) {
+                    log.info(`Updated settings for index "${uid}" (${Object.keys(pendingSettings).join(', ')})`);
+                } else {
+                    settingsPending = true;
+                    log.warn(`Settings update still processing for index "${uid}"`);
+                }
             }
 
             try {
@@ -1148,15 +1336,19 @@ async function ensureVectorIndexesReady(observedLength) {
                 log.warn(`Failed to read stats for index "${uid}"`, error);
             }
         }
+        if (settingsPending && !allowPending && !embedderReady) {
+            vectorIndexReady = false;
+            throw new Error('Vector index settings are still updating. Retry shortly.');
+        }
         if (!cardsDocs || cardsDocs <= 0) {
             vectorIndexReady = false;
             throw new Error('Vector cards index is empty. Run `npm run vector:backfill` to populate embeddings or disable vector search.');
         }
-        chunkIndexHasDocs = typeof chunksDocs === 'number' ? chunksDocs > 0 : false;
-        if (!chunkIndexHasDocs) {
+        chunkIndexHasDocs = chunksIndexUid ? (typeof chunksDocs === 'number' ? chunksDocs > 0 : false) : false;
+        if (chunksIndexUid && !chunkIndexHasDocs) {
             log.warn('Vector chunk index appears empty; chunk highlights will be disabled until you run `npm run vector:backfill`.');
         }
-        vectorIndexReady = true;
+        vectorIndexReady = embedderReady;
     })().finally(() => {
         vectorIndexSetupPromise = null;
     });
@@ -1455,12 +1647,31 @@ export async function searchVectorCards({
         : vectorSearchConfig.semanticRatio;
 
     const embedding = await fetchQueryEmbedding(text);
-    await ensureVectorIndexesReady(embedding.length);
+    await ensureVectorIndexesReady(embedding.length, {
+        waitTimeoutMs: 0,
+        allowPending: true,
+        allowFallbackWait: false
+    });
+    if (!vectorIndexReady) {
+        return {
+            ids: [],
+            total: 0,
+            appliedFilter: normalizedFilter,
+            chunkMatches: {},
+            scores: {},
+            meta: {
+                semanticRatio: effectiveSemanticRatio,
+                cardsFetched: 0,
+                chunksFetched: 0,
+                skippedReason: 'settings-pending'
+            }
+        };
+    }
 
     const cardsIndex = getVectorIndex(vectorSearchConfig.cardsIndex);
-    const chunksIndex = getVectorIndex(vectorSearchConfig.chunksIndex);
-    if (!cardsIndex || !chunksIndex) {
-        throw new Error('Vector indexes are unavailable');
+    const chunksIndex = chunksAreEnabled() ? getVectorIndex(vectorSearchConfig.chunksIndex) : null;
+    if (!cardsIndex) {
+        throw new Error('Vector cards index is unavailable');
     }
 
     const cardsLimit = computeCardFetchLimit(offset, perPage);
@@ -1485,8 +1696,8 @@ export async function searchVectorCards({
     }
     const chunkFilterExpression = adaptFilterForChunks(normalizedFilter);
 
-    const chunkSearchEnabled = chunkIndexHasDocs && Boolean(chunksIndex);
-    const [cardsResult, chunksResult] = await Promise.all([
+    const chunkSearchEnabled = chunksAreEnabled() && chunkIndexHasDocs && Boolean(chunksIndex);
+    const runVectorSearch = async () => Promise.all([
         cardsIndex.search(text, searchPayload),
         chunkSearchEnabled
             ? chunksIndex.search(text, {
@@ -1505,6 +1716,40 @@ export async function searchVectorCards({
             })
             : Promise.resolve({ hits: [] })
     ]);
+
+    let cardsResult;
+    let chunksResult;
+    try {
+        [cardsResult, chunksResult] = await runVectorSearch();
+    } catch (error) {
+        if (!isMissingEmbedderError(error)) {
+            throw error;
+        }
+        log.warn('Vector embedder missing; scheduling vector index refresh');
+        resetVectorIndexState('missing-embedder');
+        try {
+            await ensureVectorIndexesReady(embedding.length, {
+                waitTimeoutMs: 0,
+                allowPending: true,
+                allowFallbackWait: false
+            });
+        } catch (refreshError) {
+            log.warn('Vector index refresh failed', refreshError);
+        }
+        return {
+            ids: [],
+            total: 0,
+            appliedFilter: normalizedFilter,
+            chunkMatches: {},
+            scores: {},
+            meta: {
+                semanticRatio: effectiveSemanticRatio,
+                cardsFetched: 0,
+                chunksFetched: 0,
+                skippedReason: 'embedder-missing'
+            }
+        };
+    }
 
     const cardHits = Array.isArray(cardsResult?.hits) ? cardsResult.hits : [];
     const chunkHits = Array.isArray(chunksResult?.hits) ? chunksResult.hits : [];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@
 #   3. Create config.json (or let container create default)
 #   4. Run: docker compose up -d
 
-version: '3.8'
-
 services:
   # ==========================================================================
   # Character Archive Application
@@ -63,20 +61,28 @@ services:
   # Meilisearch - Full-text search engine
   # ==========================================================================
   meilisearch:
-    image: getmeili/meilisearch:v1.11
-    container_name: meilisearch
+    image: getmeili/meilisearch:v1.40.0
+    container_name: localchub-meilisearch
     ports:
       - "${MEILI_PORT:-7700}:7700"
     volumes:
-      - ./meili-data:/meili_data
+      - ./data.ms:/meili_data/data.ms
+      - ./dumps:/meili_data/dumps
+      - ./snapshots:/meili_data/snapshots
     environment:
       - MEILI_ENV=production
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-}
       - MEILI_NO_ANALYTICS=true
+      - MEILI_DB_PATH=/meili_data/data.ms
+      - MEILI_DUMP_DIR=/meili_data/dumps
+      - MEILI_SNAPSHOT_DIR=/meili_data/snapshots
+      - MEILI_MAX_INDEXING_MEMORY=24GiB
       # Increase payload limit for batch indexing
       - MEILI_HTTP_PAYLOAD_SIZE_LIMIT=104857600
+    mem_limit: 32g
+    memswap_limit: 32g
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:7700/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7700/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ This guide covers running Character Archive using Docker and Docker Compose.
 ## Prerequisites
 
 - Docker 20.10+ and Docker Compose v2
-- ~2GB RAM minimum (4GB+ recommended for Meilisearch)
+- Enough RAM for your chosen Meilisearch cap. The bundled compose file currently caps Meilisearch at `32 GiB` and sets `MEILI_MAX_INDEXING_MEMORY=24GiB`.
 - Storage for your card collection (varies by usage)
 
 ## Quick Start
@@ -29,7 +29,7 @@ cp .env.example .env
 ### 3. Create data directories
 
 ```bash
-mkdir -p static meili-data
+mkdir -p static data.ms dumps snapshots
 touch cards.db
 ```
 
@@ -72,6 +72,9 @@ The container creates a default `config.json` on first run. To customize:
     },
     "vectorSearch": {
         "enabled": false,
+        "enableChunks": false,
+        "cardsIndex": "cards_vsem",
+        "chunksIndex": "card_chunks",
         "ollamaUrl": "http://host.docker.internal:11434",
         "embedModel": "snowflake-arctic-embed2:latest"
     },
@@ -89,6 +92,8 @@ The container creates a default `config.json` on first run. To customize:
 ```
 
 2. Mount it as read-only in docker-compose.yml (already configured)
+
+`enableChunks: false` keeps vector search on the whole-card index only. Set it to `true` if you also want semantic snippets/chunk reranking via the optional `card_chunks` index.
 
 ### Environment Variables
 
@@ -108,7 +113,9 @@ The container creates a default `config.json` on first run. To customize:
 | `/app/static` | `./static` | Card images and JSON files |
 | `/app/cards.db` | `./cards.db` | SQLite database |
 | `/app/config.json` | `./config.json` | Application configuration |
-| `/meili_data` | `./meili-data` | Meilisearch index data |
+| `/meili_data/data.ms` | `./data.ms` | Meilisearch database files |
+| `/meili_data/dumps` | `./dumps` | Meilisearch dumps |
+| `/meili_data/snapshots` | `./snapshots` | Meilisearch snapshots |
 
 ## Using with Ollama
 
@@ -218,6 +225,9 @@ docker exec character-archive node scripts/sync-meilisearch.js
 
 # Vector backfill (if Ollama configured)
 docker exec character-archive node scripts/etl_cards_vector_search.js
+
+# Remove only the optional chunk vector index/artifacts
+docker exec character-archive node scripts/flush-vector-indexes.js --chunks-only
 ```
 
 ## Troubleshooting
@@ -248,6 +258,7 @@ Common issues:
        "host": "http://meilisearch:7700"
    }
    ```
+3. If `vectorSearch.enableChunks` is `false`, `card_chunks` being absent is expected. Whole-card semantic search still works without that index.
 
 ### Can't connect from other machines
 

--- a/frontend/app/components/SettingsModal.tsx
+++ b/frontend/app/components/SettingsModal.tsx
@@ -48,6 +48,7 @@ type SettingsModalProps = {
     };
     defaultVectorSearchState: {
         enabled: boolean;
+        enableChunks: boolean;
         cardsIndex: string;
         chunksIndex: string;
         embedModel: string;
@@ -857,6 +858,20 @@ export const SettingsModal = ({
                                         <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                                             Meilisearch + Ollama
                                         </h3>
+                                        <label className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                                            <input
+                                                type="checkbox"
+                                                name="vector_enableChunks"
+                                                defaultChecked={config?.vectorSearch?.enableChunks ?? defaultVectorSearchState.enableChunks}
+                                                className="mt-1 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900"
+                                            />
+                                            <span className="space-y-1">
+                                                <span className="block font-medium">Enable chunk vectors</span>
+                                                <span className="block text-xs text-slate-500 dark:text-slate-400">
+                                                    Keep this on if you want semantic snippets and chunk-level reranking. Turn it off to use only the whole-card vector index and skip building <code>card_chunks</code>.
+                                                </span>
+                                            </span>
+                                        </label>
                                         <div className="grid gap-4 md:grid-cols-2">
                                             <label className="flex flex-col gap-2 text-sm">
                                                 <span className="font-medium text-slate-700 dark:text-slate-300">Cards index UID</span>
@@ -977,13 +992,13 @@ export const SettingsModal = ({
                                             </summary>
                                             <div className="mt-3 space-y-2 leading-relaxed">
                                                 <p>
-                                                    <strong>Enable</strong> only after both Meili indexes (<code>cards_vsem</code> + <code>card_chunks</code>) are populated. The cards index stores one embedding per narrative section, while the chunk index stores every over-length section or alternate greeting.
+                                                    <strong>Vector search</strong> needs the cards index populated. Chunk vectors are optional: keep <code>Enable chunk vectors</code> on only if you also want the <code>card_chunks</code> index and semantic snippets.
                                                 </p>
                                                 <p>
                                                     <strong>Ollama URL &amp; Embed model</strong> must match whatever powered the backfill. Changing the model requires regenerating embeddings or results will be meaningless.
                                                 </p>
                                                 <p>
-                                                    <strong>Cards / chunk indexes</strong> tell the API which Meili UID to query. Keep them in sync with whatever UID you swap into production (e.g. <code>cards_vsem</code> while it is staged, <code>cards</code> once you swap).
+                                                    <strong>Cards / chunk indexes</strong> tell the API which Meili UID to query. When chunk vectors are disabled, the chunk UID is ignored and can stay reserved for later.
                                                 </p>
                                                 <p>
                                                     <strong>Semantic ratio</strong> biases Meili between lexical and vector scoring. Values around 0.3‑0.5 keep keyword intent intact; go lower for proper nouns, higher for vibes.
@@ -992,7 +1007,7 @@ export const SettingsModal = ({
                                                     <strong>Cards multiplier</strong> controls how many lexical hits we fetch before fusing with chunk hits. If exact matches disappear, bump this toward 3‑4 so the baseline list stays deep enough.
                                                 </p>
                                                 <p>
-                                                    <strong>Chunk limit / weight</strong> governs how many chunk-only hits are allowed to outrank lexical ones. Lower the weight if semantic snippets drown out obvious keyword matches; raise it when you want long-form alternates to drive the ranking.
+                                                    <strong>Chunk limit / weight</strong> only apply when chunk vectors are enabled. Lower the weight if semantic snippets drown out obvious keyword matches; raise it when you want long-form alternates to drive the ranking.
                                                 </p>
                                                 <p>
                                                     <strong>RRF k</strong> is the denominator inside reciprocal-rank fusion. Higher values flatten the advantage of top-ranked items; leave it at 60 unless you have a reason to rebalance the curve.

--- a/frontend/app/hooks/useConfig.ts
+++ b/frontend/app/hooks/useConfig.ts
@@ -155,6 +155,7 @@ export function useConfig(): UseConfigResult {
       const vectorConfig = {
         ...previousVector,
         enabled: data.get("vector_enabled") === "on",
+        enableChunks: data.get("vector_enableChunks") === "on",
         cardsIndex: getStringValue("vector_cardsIndex", { trim: true }) || previousVector.cardsIndex,
         chunksIndex: getStringValue("vector_chunksIndex", { trim: true }) || previousVector.chunksIndex,
         embedModel: getStringValue("vector_embedModel", { trim: true }) || previousVector.embedModel,

--- a/frontend/app/types/config.ts
+++ b/frontend/app/types/config.ts
@@ -37,6 +37,7 @@ export const defaultCtSyncState = {
 
 export const defaultVectorSearchState = {
     enabled: false,
+    enableChunks: true,
     cardsIndex: 'cards_vsem',
     chunksIndex: 'card_chunks',
     embedModel: 'snowflake-arctic-embed2:latest',

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -149,6 +149,7 @@ export interface Config {
   };
   vectorSearch?: {
     enabled: boolean;
+    enableChunks?: boolean;
     cardsIndex: string;
     chunksIndex: string;
     embedModel: string;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "sync:search": "node scripts/sync-meilisearch.js",
     "fix:flags": "node scripts/fix-feature-flags.js",
     "vector:backfill": "node scripts/etl_cards_vector_search.js",
-    "vector:flush": "node scripts/flush-vector-indexes.js"
+    "vector:flush": "node scripts/flush-vector-indexes.js",
+    "vector:embedders": "node scripts/ensure-vector-embedders.js",
+    "optimize:pngs": "node scripts/optimize-pngs.js"
   },
   "keywords": [
     "chub",
@@ -55,6 +57,7 @@
     "png-chunk-text": "^1.0.0",
     "png-chunks-encode": "^1.0.0",
     "png-chunks-extract": "^1.0.0",
+    "sharp": "^0.33.5",
     "sqlite3": "^5.1.7",
     "unzipper": "^0.12.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       png-chunks-extract:
         specifier: ^1.0.0
         version: 1.0.0
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       sqlite3:
         specifier: ^5.1.7
         version: 5.1.7
@@ -3853,7 +3856,6 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.4
-    optional: true
 
   color-support@1.1.3:
     optional: true
@@ -3862,7 +3864,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -4432,8 +4433,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  is-arrayish@0.3.4:
-    optional: true
+  is-arrayish@0.3.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -5099,7 +5099,6 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -5157,7 +5156,6 @@ snapshots:
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
-    optional: true
 
   simple-update-notifier@2.0.0:
     dependencies:

--- a/scripts/ensure-vector-embedders.js
+++ b/scripts/ensure-vector-embedders.js
@@ -3,6 +3,14 @@
 import { MeiliSearch } from 'meilisearch';
 import { loadConfig } from '../config.js';
 
+function readBooleanFlag(value, fallback = false) {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    return !['0', 'false', 'no', 'off'].includes(normalized);
+}
+
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -144,12 +152,15 @@ async function main() {
     const dimensions = Number(process.env.EMBED_DIMENSIONS || vector.embedDimensions || 0);
     const cardsIndex = (process.env.MEILI_CARDS_INDEX || vector.cardsIndex || 'cards_vsem').trim();
     const chunksIndex = (process.env.MEILI_CHUNKS_INDEX || vector.chunksIndex || 'card_chunks').trim();
+    const enableChunks = readBooleanFlag(process.env.MEILI_ENABLE_CHUNKS, vector.enableChunks !== false);
 
-    console.log(`[INFO] Ensuring embedders for ${cardsIndex} / ${chunksIndex} on ${host}`);
+    console.log(`[INFO] Ensuring embedders for ${cardsIndex}${enableChunks ? ` / ${chunksIndex}` : ' (chunks disabled)'} on ${host}`);
 
     const client = new MeiliSearch({ host, apiKey });
     await ensureEmbedder(cardsIndex, embedderName, dimensions, client);
-    await ensureEmbedder(chunksIndex, embedderName, dimensions, client);
+    if (enableChunks) {
+        await ensureEmbedder(chunksIndex, embedderName, dimensions, client);
+    }
 
     console.log('[INFO] Embedder settings verified');
     process.exit(0);

--- a/scripts/ensure-vector-embedders.js
+++ b/scripts/ensure-vector-embedders.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { MeiliSearch } from 'meilisearch';
+import { loadConfig } from '../config.js';
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForTask(taskClient, taskUid, timeoutMs = 60_000, label = 'Meili task') {
+    if (!taskClient || !taskUid) return;
+    if (typeof taskClient.getTask !== 'function') {
+        if (typeof taskClient.waitForTask === 'function') {
+            await taskClient.waitForTask(taskUid, { timeOutMs: timeoutMs });
+        }
+        return;
+    }
+    const start = Date.now();
+    let lastLog = 0;
+    while (true) {
+        const task = await taskClient.getTask(taskUid);
+        const status = task?.status || 'unknown';
+        const elapsedSec = Math.floor((Date.now() - start) / 1000);
+        if (Date.now() - lastLog > 2000) {
+            console.log(`[INFO] ${label} ${taskUid} status=${status} elapsed=${elapsedSec}s`);
+            lastLog = Date.now();
+        }
+        if (status === 'succeeded' || status === 'failed' || status === 'canceled') {
+            return;
+        }
+        if (Date.now() - start > timeoutMs) {
+            throw new Error(`Timed out waiting for task ${taskUid} after ${elapsedSec}s (status=${status})`);
+        }
+        await sleep(500);
+    }
+}
+
+function isIndexMissing(error) {
+    const message = String(error?.message || '');
+    return message.includes('index_not_found') || message.includes('not found');
+}
+
+async function ensureIndex(client, indexUid, primaryKey = 'id') {
+    if (!indexUid) {
+        throw new Error('Missing index UID');
+    }
+    try {
+        await client.getIndex(indexUid);
+    } catch (error) {
+        if (!isIndexMissing(error)) {
+            throw error;
+        }
+        await client.createIndex(indexUid, { primaryKey });
+    }
+    return client.index(indexUid);
+}
+
+async function hasPendingSettingsUpdate(client, indexUid) {
+    if (!client?.tasks || typeof client.tasks.getTasks !== 'function') {
+        return false;
+    }
+    const uid = (indexUid || '').trim();
+    if (!uid) return false;
+    try {
+        const tasks = await client.tasks.getTasks({
+            indexUids: [uid],
+            types: ['settingsUpdate'],
+            statuses: ['enqueued', 'processing'],
+            limit: 1
+        });
+        const results = Array.isArray(tasks?.results) ? tasks.results : [];
+        return results.length > 0;
+    } catch (error) {
+        console.warn('[WARN] Failed to check Meilisearch task queue:', error?.message || error);
+        return false;
+    }
+}
+
+async function ensureEmbedder(indexUid, embedderName, dimensions, client) {
+    if (!indexUid) return;
+    if (!embedderName) {
+        throw new Error('Embedder name is missing. Set vectorSearch.embedderName or MEILI_EMBEDDER.');
+    }
+    if (!Number.isFinite(dimensions) || dimensions <= 0) {
+        throw new Error('Embed dimensions missing. Set vectorSearch.embedDimensions or EMBED_DIMENSIONS.');
+    }
+
+    const index = await ensureIndex(client, indexUid, 'id');
+    let settings = {};
+    try {
+        settings = await index.getSettings();
+    } catch (error) {
+        console.warn(`[WARN] Failed to read settings for ${indexUid}: ${error?.message || error}`);
+    }
+
+    const embedders = settings?.embedders || {};
+    const current = embedders[embedderName];
+    const currentDims = Number(current?.dimensions);
+    if (current && Number.isFinite(currentDims) && currentDims === dimensions) {
+        console.log(`[INFO] ${indexUid}: embedder "${embedderName}" already set (${dimensions}d)`);
+        return;
+    }
+    const pending = await hasPendingSettingsUpdate(client, indexUid);
+    if (pending) {
+        console.log(`[WARN] ${indexUid}: settings update already pending; skipping new update.`);
+        return;
+    }
+
+    const task = await index.updateSettings({
+        embedders: {
+            ...embedders,
+            [embedderName]: {
+                source: 'userProvided',
+                dimensions
+            }
+        }
+    });
+    const taskId = task?.taskUid ?? task?.uid;
+    if (taskId) {
+        await waitForTask(client.tasks, taskId, 60_000, `Meili settings (${indexUid})`).catch(error => {
+            console.warn(`[WARN] Timed out waiting for task ${taskId}: ${error?.message || error}`);
+        });
+    }
+    console.log(`[INFO] ${indexUid}: embedder "${embedderName}" set to ${dimensions}d`);
+}
+
+async function main() {
+    const config = loadConfig();
+    const meili = config?.meilisearch || {};
+    const vector = config?.vectorSearch || {};
+
+    const host = (process.env.MEILI_HOST || meili.host || '').trim();
+    if (!host) {
+        console.error('[FATAL] Missing Meilisearch host. Set MEILI_HOST or config.meilisearch.host');
+        process.exit(1);
+    }
+    const apiKey = (process.env.MEILI_KEY || meili.apiKey || meili.key || '').trim();
+    if (!apiKey) {
+        console.error('[FATAL] Missing Meilisearch API key. Set MEILI_KEY or config.meilisearch.apiKey');
+        process.exit(1);
+    }
+
+    const embedderName = (process.env.MEILI_EMBEDDER || vector.embedderName || '').trim();
+    const dimensions = Number(process.env.EMBED_DIMENSIONS || vector.embedDimensions || 0);
+    const cardsIndex = (process.env.MEILI_CARDS_INDEX || vector.cardsIndex || 'cards_vsem').trim();
+    const chunksIndex = (process.env.MEILI_CHUNKS_INDEX || vector.chunksIndex || 'card_chunks').trim();
+
+    console.log(`[INFO] Ensuring embedders for ${cardsIndex} / ${chunksIndex} on ${host}`);
+
+    const client = new MeiliSearch({ host, apiKey });
+    await ensureEmbedder(cardsIndex, embedderName, dimensions, client);
+    await ensureEmbedder(chunksIndex, embedderName, dimensions, client);
+
+    console.log('[INFO] Embedder settings verified');
+    process.exit(0);
+}
+
+main().catch(error => {
+    console.error('[FATAL] Failed to ensure embedders:', error?.message || error);
+    process.exit(1);
+});

--- a/scripts/etl_cards_vector_search.js
+++ b/scripts/etl_cards_vector_search.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import { fileURLToPath } from 'url';
+import { MeiliSearch } from 'meilisearch';
 import { initDatabase, getDatabase } from '../backend/database.js';
 import { loadConfig } from '../config.js';
 import { readCardPngSpec, getCardFilePaths } from '../backend/utils/card-utils.js';
@@ -15,6 +16,7 @@ const config = loadConfig();
 const DEFAULT_OLLAMA_URL = process.env.OLLAMA_URL || config.vectorSearch?.ollamaUrl || 'http://127.0.0.1:11434';
 const EMBED_MODEL = process.env.EMBED_MODEL || config.vectorSearch?.embedModel || 'snowflake-arctic-embed2:latest';
 const EMBEDDER_NAME = process.env.MEILI_EMBEDDER || config.vectorSearch?.embedderName || 'arctic2-1024';
+const EMBED_DIMENSIONS = Number(process.env.EMBED_DIMENSIONS || config.vectorSearch?.embedDimensions || 0);
 const CHUNK_TOKEN_THRESHOLD = Number(process.env.CHUNK_TOKEN_THRESHOLD || 300);
 const CHUNK_TARGET_CHARS = Number(process.env.CHUNK_CHAR_TARGET || 1200);
 const CHUNK_CHAR_OVERLAP = Number(process.env.CHUNK_CHAR_OVERLAP || 300);
@@ -23,6 +25,18 @@ const LOG_EVERY = Number(process.env.LOG_EVERY || 25);
 const CARD_LIMIT = process.env.LCR_VECTOR_LIMIT ? Number(process.env.LCR_VECTOR_LIMIT) : null;
 const START_AFTER = process.env.LCR_VECTOR_START_AFTER ? Number(process.env.LCR_VECTOR_START_AFTER) : null;
 const FORCE_REEMBED = process.env.LCR_VECTOR_FORCE === '1';
+const VERIFY_DOCS = process.env.LCR_VECTOR_VERIFY === '1';
+const QUEUE_MODE = process.env.LCR_VECTOR_QUEUE === '1';
+const QUEUE_BATCH = process.env.LCR_VECTOR_QUEUE_BATCH ? Number(process.env.LCR_VECTOR_QUEUE_BATCH) : null;
+const OLLAMA_TIMEOUT_MS = Number(process.env.OLLAMA_TIMEOUT_MS || 120000);
+const OLLAMA_RETRIES = Number(process.env.OLLAMA_RETRIES || 2);
+const OLLAMA_RETRY_BACKOFF_MS = Number(process.env.OLLAMA_RETRY_BACKOFF_MS || 1000);
+const OLLAMA_SPLIT_DEPTH = Number(process.env.OLLAMA_SPLIT_DEPTH || 4);
+const EMBED_BATCH_SIZE = Number(process.env.OLLAMA_EMBED_BATCH || config.vectorSearch?.embedBatchSize || 0);
+const IDS_FILTER = process.env.LCR_VECTOR_IDS || '';
+const DELETE_IDS_FILTER = process.env.LCR_VECTOR_DELETE_IDS || '';
+const QUEUE_ROW_IDS_FILTER = process.env.LCR_VECTOR_QUEUE_IDS || '';
+const ENABLE_CHUNK_INDEX = readBooleanFlag(process.env.MEILI_ENABLE_CHUNKS, config.vectorSearch?.enableChunks !== false);
 
 // Support multiple Ollama instances via comma-separated URLs in config or env var
 const SECONDARY_OLLAMA_URL = process.env.OLLAMA_URL_SECONDARY || config.vectorSearch?.ollamaUrlSecondary || null;
@@ -32,10 +46,15 @@ let OLLAMA_INSTANCES = [DEFAULT_OLLAMA_URL];
 let ollamaRoundRobin = 0;
 const MEILI_HOST = (process.env.MEILI_HOST || config.meilisearch.host || '').replace(/\/$/, '');
 const MEILI_KEY = process.env.MEILI_KEY || config.meilisearch.apiKey || '';
-const CARDS_INDEX = process.env.MEILI_CARDS_INDEX || 'cards_vsem';
-const CHUNKS_INDEX = process.env.MEILI_CHUNKS_INDEX || 'card_chunks';
+const CARDS_INDEX = process.env.MEILI_CARDS_INDEX || config.vectorSearch?.cardsIndex || 'cards_vsem';
+const CHUNKS_INDEX = process.env.MEILI_CHUNKS_INDEX || config.vectorSearch?.chunksIndex || 'card_chunks';
 const DEBUG_DUMP_DIR = process.env.VECTOR_DEBUG_DIR || null;
 let debugDocCounter = 0;
+let forceReembedAll = FORCE_REEMBED;
+let forceChunkReembed = FORCE_REEMBED;
+let verifyCardDocs = VERIFY_DOCS;
+let cardsIndexClient = null;
+let chunksIndexClient = null;
 
 if (!MEILI_HOST || !MEILI_KEY) {
     console.error('[FATAL] Missing Meilisearch host or API key. Set MEILI_HOST/MEILI_KEY or config.meilisearch.');
@@ -46,6 +65,8 @@ if (typeof fetch !== 'function') {
     console.error('[FATAL] Global fetch is unavailable. Run on Node.js 18+ or polyfill fetch.');
     process.exit(1);
 }
+
+const meiliClient = new MeiliSearch({ host: MEILI_HOST, apiKey: MEILI_KEY });
 
 const jsonHeaders = {
     'Content-Type': 'application/json',
@@ -60,6 +81,45 @@ const stats = {
     chunkUpdates: 0,
     chunkDeletes: 0
 };
+
+const CARD_SELECT_FIELDS = [
+    'id',
+    'name',
+    'tagline',
+    'description',
+    'topics',
+    'tokenCount',
+    'tokenDescriptionCount',
+    'tokenPersonalityCount',
+    'tokenScenarioCount',
+    'tokenMesExampleCount',
+    'tokenFirstMessageCount',
+    'tokenSystemPromptCount',
+    'tokenPostHistoryCount',
+    'author',
+    'language',
+    'source',
+    'sourceId',
+    'sourcePath',
+    'sourceUrl',
+    'visibility',
+    'favorited',
+    'hasAlternateGreetings',
+    'hasLorebook',
+    'hasEmbeddedLorebook',
+    'hasLinkedLorebook',
+    'hasExampleDialogues',
+    'hasSystemPrompt',
+    'hasGallery',
+    'isFuzzed',
+    'lastModified',
+    'createdAt',
+    'nChats',
+    'nMessages',
+    'n_favorites',
+    'starCount',
+    'fullPath'
+].join(', ');
 
 function approxTokenCount(text = '') {
     if (!text) return 0;
@@ -86,6 +146,144 @@ function splitTopics(topics) {
         .split(',')
         .map(t => t.trim())
         .filter(Boolean);
+}
+
+function splitArray(items, size) {
+    if (!Array.isArray(items) || items.length === 0) {
+        return [];
+    }
+    if (!Number.isFinite(size) || size <= 0 || size >= items.length) {
+        return [items];
+    }
+    const batches = [];
+    for (let i = 0; i < items.length; i += size) {
+        batches.push(items.slice(i, i + size));
+    }
+    return batches;
+}
+
+function parseIdList(value) {
+    if (!value) return [];
+    const raw = Array.isArray(value) ? value.join(',') : String(value);
+    const tokens = raw.split(/[,\s]+/).map(token => token.trim()).filter(Boolean);
+    return Array.from(new Set(tokens));
+}
+
+function readBooleanFlag(value, fallback = false) {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    return !['0', 'false', 'no', 'off'].includes(normalized);
+}
+
+function isIndexMissing(error) {
+    const message = String(error?.message || '');
+    return message.includes('index_not_found') || message.includes('not found');
+}
+
+function isAbortError(error) {
+    return error?.name === 'AbortError' || error?.code === 'ABORT_ERR' || String(error?.message || '').includes('aborted');
+}
+
+function isRetryableOllamaError(error) {
+    if (isAbortError(error)) return true;
+    const message = String(error?.message || '');
+    return /fetch failed|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|503|504/i.test(message);
+}
+
+function shouldSplitBatch(error) {
+    const message = String(error?.message || '');
+    return isAbortError(error) || /413|payload too large|request entity too large/i.test(message);
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function ensureIndex(indexUid, primaryKey = 'id') {
+    if (!indexUid) {
+        throw new Error('Missing index UID');
+    }
+    try {
+        await meiliClient.getIndex(indexUid);
+    } catch (error) {
+        if (!isIndexMissing(error)) {
+            throw error;
+        }
+        await meiliClient.createIndex(indexUid, { primaryKey });
+    }
+    return meiliClient.index(indexUid);
+}
+
+async function ensureEmbedderSettings(indexUid, dimensions) {
+    if (!indexUid) return;
+    if (!EMBEDDER_NAME) {
+        console.warn('[WARN] No embedder name configured; skipping embedder settings.');
+        return;
+    }
+    if (!Number.isFinite(dimensions) || dimensions <= 0) {
+        console.warn(`[WARN] Embed dimensions missing for ${indexUid}; skipping embedder settings.`);
+        return;
+    }
+    const index = await ensureIndex(indexUid, 'id');
+    let settings = {};
+    try {
+        settings = await index.getSettings();
+    } catch (error) {
+        console.warn(`[WARN] Failed to read settings for ${indexUid}: ${error?.message || error}`);
+    }
+    const embedders = settings?.embedders || {};
+    const current = embedders[EMBEDDER_NAME];
+    const currentDims = Number(current?.dimensions);
+    if (current && Number.isFinite(currentDims) && currentDims === dimensions) {
+        return;
+    }
+    const task = await index.updateSettings({
+        embedders: {
+            ...embedders,
+            [EMBEDDER_NAME]: {
+                source: 'userProvided',
+                dimensions
+            }
+        }
+    });
+    const taskId = task?.taskUid ?? task?.uid;
+    console.log(`[INFO] Scheduled embedder "${EMBEDDER_NAME}" for ${indexUid} (${dimensions}d)${taskId ? ` task ${taskId}` : ''}`);
+}
+
+function isDocumentMissing(error) {
+    const message = String(error?.message || '');
+    return message.includes('document_not_found') || message.includes('not found');
+}
+
+async function cardDocHasVectors(cardId, expectedSections = []) {
+    if (!cardsIndexClient) {
+        return true;
+    }
+    try {
+        const doc = await cardsIndexClient.getDocument(String(cardId), {
+            fields: ['id', 'vector_sections']
+        });
+        const sections = Array.isArray(doc?.vector_sections) ? doc.vector_sections : [];
+        if (!sections.length) {
+            return false;
+        }
+        if (expectedSections.length) {
+            const sectionSet = new Set(sections);
+            for (const section of expectedSections) {
+                if (!sectionSet.has(section)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    } catch (error) {
+        if (isDocumentMissing(error)) {
+            return false;
+        }
+        throw error;
+    }
 }
 
 function collectAlternateGreetings(specData = {}, metadata = {}) {
@@ -166,6 +364,66 @@ async function checkOllamaInstance(url) {
     }
 }
 
+async function requestEmbeddings(url, texts, timeoutMs) {
+    const body = JSON.stringify({ model: EMBED_MODEL, input: texts });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            signal: controller.signal
+        });
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`[OLLAMA ${url}] ${response.status} ${response.statusText} — ${errorText}`);
+        }
+        const payload = await response.json();
+        const vectors = payload?.embeddings;
+        if (!Array.isArray(vectors) || vectors.length !== texts.length) {
+            throw new Error('[OLLAMA] Embed response malformed or length mismatch');
+        }
+        return vectors;
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+async function embedWithRetry(url, texts, { retries = OLLAMA_RETRIES, timeoutMs = OLLAMA_TIMEOUT_MS, fallbackUrl = null, depth = 0 } = {}) {
+    try {
+        return await requestEmbeddings(url, texts, timeoutMs);
+    } catch (error) {
+        const message = String(error?.message || '');
+        const retryable = isRetryableOllamaError(error);
+
+        if (texts.length > 1 && depth < OLLAMA_SPLIT_DEPTH && shouldSplitBatch(error)) {
+            const mid = Math.ceil(texts.length / 2);
+            const left = texts.slice(0, mid);
+            const right = texts.slice(mid);
+            console.warn(`[WARN] Ollama batch failed (${message}). Splitting ${texts.length} → ${left.length}+${right.length}`);
+            const leftVectors = await embedWithRetry(url, left, { retries, timeoutMs, fallbackUrl, depth: depth + 1 });
+            const rightVectors = await embedWithRetry(url, right, { retries, timeoutMs, fallbackUrl, depth: depth + 1 });
+            return [...leftVectors, ...rightVectors];
+        }
+
+        if (retryable && retries > 0) {
+            const attempt = OLLAMA_RETRIES - retries + 1;
+            const backoff = OLLAMA_RETRY_BACKOFF_MS * Math.pow(2, attempt - 1);
+            console.warn(`[WARN] Ollama request failed (${message}). Retrying in ${backoff}ms (attempt ${attempt}/${OLLAMA_RETRIES})`);
+            await sleep(backoff);
+            return embedWithRetry(url, texts, { retries: retries - 1, timeoutMs, fallbackUrl, depth });
+        }
+
+        if (fallbackUrl && fallbackUrl !== url) {
+            console.warn(`[WARN] Falling back to ${fallbackUrl} for failed Ollama batch: ${message}`);
+            return embedWithRetry(fallbackUrl, texts, { retries: OLLAMA_RETRIES, timeoutMs, fallbackUrl: null, depth });
+        }
+
+        throw error;
+    }
+}
+
 async function embedBatch(texts) {
     if (!texts.length) {
         return [];
@@ -175,23 +433,9 @@ async function embedBatch(texts) {
     const ollamaUrl = OLLAMA_INSTANCES[ollamaRoundRobin % OLLAMA_INSTANCES.length];
     ollamaRoundRobin++;
 
-    const body = JSON.stringify({ model: EMBED_MODEL, input: texts });
     const url = `${ollamaUrl}/api/embed`;
-    const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body
-    });
-    if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`[OLLAMA] ${response.status} ${response.statusText} — ${errorText}`);
-    }
-    const payload = await response.json();
-    const vectors = payload?.embeddings;
-    if (!Array.isArray(vectors) || vectors.length !== texts.length) {
-        throw new Error('[OLLAMA] Embed response malformed or length mismatch');
-    }
-    return vectors;
+    const fallbackUrl = ollamaUrl !== DEFAULT_OLLAMA_URL ? `${DEFAULT_OLLAMA_URL}/api/embed` : null;
+    return embedWithRetry(url, texts, { fallbackUrl });
 }
 
 async function embedBatchParallel(texts) {
@@ -214,59 +458,29 @@ async function embedBatchParallel(texts) {
     // Embed in parallel across instances with retry and fallback
     const promises = chunks.map(async (chunk, idx) => {
         const ollamaUrl = OLLAMA_INSTANCES[idx % OLLAMA_INSTANCES.length];
-        const body = JSON.stringify({ model: EMBED_MODEL, input: chunk });
         const url = `${ollamaUrl}/api/embed`;
-
-        // Try with extended timeout (60s for large batches)
-        try {
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 60000);
-
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body,
-                signal: controller.signal
-            });
-
-            clearTimeout(timeoutId);
-
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`[OLLAMA ${ollamaUrl}] ${response.status} ${response.statusText} — ${errorText}`);
-            }
-            const payload = await response.json();
-            return payload?.embeddings || [];
-        } catch (error) {
-            // If secondary instance fails, fall back to primary for this chunk
-            if (ollamaUrl !== DEFAULT_OLLAMA_URL) {
-                console.warn(`[WARN] Secondary instance ${ollamaUrl} failed, falling back to primary for this batch: ${error.message}`);
-                const fallbackUrl = `${DEFAULT_OLLAMA_URL}/api/embed`;
-                const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 60000);
-
-                const response = await fetch(fallbackUrl, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body,
-                    signal: controller.signal
-                });
-
-                clearTimeout(timeoutId);
-
-                if (!response.ok) {
-                    const errorText = await response.text();
-                    throw new Error(`[OLLAMA FALLBACK] ${response.status} ${response.statusText} — ${errorText}`);
-                }
-                const payload = await response.json();
-                return payload?.embeddings || [];
-            }
-            throw error;
-        }
+        const fallbackUrl = ollamaUrl !== DEFAULT_OLLAMA_URL ? `${DEFAULT_OLLAMA_URL}/api/embed` : null;
+        return embedWithRetry(url, chunk, { fallbackUrl });
     });
 
     const results = await Promise.all(promises);
     return results.flat();
+}
+
+async function embedTexts(texts) {
+    if (!texts.length) {
+        return [];
+    }
+    const batchSize = Number.isFinite(EMBED_BATCH_SIZE) && EMBED_BATCH_SIZE > 0
+        ? Math.floor(EMBED_BATCH_SIZE)
+        : texts.length;
+    const batches = splitArray(texts, batchSize);
+    const vectors = [];
+    for (const batch of batches) {
+        const batchVectors = await embedBatchParallel(batch);
+        vectors.push(...batchVectors);
+    }
+    return vectors;
 }
 
 async function meiliAddDocuments(indexUid, documents) {
@@ -404,40 +618,41 @@ async function handleCard(row, db) {
         }
     }
 
-    let cardNeedsUpdate = FORCE_REEMBED || staleCardMeta.length > 0 || cardSectionEntries.some(entry => {
+    let cardNeedsUpdate = forceReembedAll || staleCardMeta.length > 0 || cardSectionEntries.some(entry => {
         const key = `${entry.section}#-1`;
         const prev = cardMetaMap.get(key);
         return !prev || prev.textHash !== entry.hash;
     });
 
     const chunkSections = [];
-
-    if (altGreetings.length) {
-        altGreetings.forEach((greeting, idx) => {
-            const slices = splitIntoChunks(greeting, { target: CHUNK_TARGET_CHARS, overlap: CHUNK_CHAR_OVERLAP });
-            slices.forEach((slice, sliceIndex) => {
-                chunkSections.push({
-                    section: 'alt_greeting',
-                    text: slice.text,
-                    approxStart: slice.start,
-                    logicalIndex: `${idx}-${sliceIndex}`
+    if (ENABLE_CHUNK_INDEX) {
+        if (altGreetings.length) {
+            altGreetings.forEach((greeting, idx) => {
+                const slices = splitIntoChunks(greeting, { target: CHUNK_TARGET_CHARS, overlap: CHUNK_CHAR_OVERLAP });
+                slices.forEach((slice, sliceIndex) => {
+                    chunkSections.push({
+                        section: 'alt_greeting',
+                        text: slice.text,
+                        approxStart: slice.start,
+                        logicalIndex: `${idx}-${sliceIndex}`
+                    });
                 });
             });
-        });
-    }
+        }
 
-    for (const baseSection of baseSections) {
-        const tokenEstimate = approxTokenCount(baseSection.text);
-        if (tokenEstimate > CHUNK_TOKEN_THRESHOLD) {
-            const slices = splitIntoChunks(baseSection.text, { target: CHUNK_TARGET_CHARS, overlap: CHUNK_CHAR_OVERLAP });
-            slices.forEach((slice, sliceIndex) => {
-                chunkSections.push({
-                    section: baseSection.section,
-                    text: slice.text,
-                    approxStart: slice.start,
-                    logicalIndex: `${baseSection.section}-${sliceIndex}`
+        for (const baseSection of baseSections) {
+            const tokenEstimate = approxTokenCount(baseSection.text);
+            if (tokenEstimate > CHUNK_TOKEN_THRESHOLD) {
+                const slices = splitIntoChunks(baseSection.text, { target: CHUNK_TARGET_CHARS, overlap: CHUNK_CHAR_OVERLAP });
+                slices.forEach((slice, sliceIndex) => {
+                    chunkSections.push({
+                        section: baseSection.section,
+                        text: slice.text,
+                        approxStart: slice.start,
+                        logicalIndex: `${baseSection.section}-${sliceIndex}`
+                    });
                 });
-            });
+            }
         }
     }
 
@@ -476,17 +691,28 @@ async function handleCard(row, db) {
         }
     }
 
-    const chunkEmbedsNeeded = FORCE_REEMBED
+    const chunkEmbedsNeeded = ENABLE_CHUNK_INDEX && forceChunkReembed
         ? newChunkEntries
-        : newChunkEntries.filter(entry => {
-            const key = `${entry.section}#${entry.chunkIndex}`;
-            const prev = chunkMetaMap.get(key);
-            return !prev || prev.textHash !== entry.hash;
-        });
+        : ENABLE_CHUNK_INDEX
+            ? newChunkEntries.filter(entry => {
+                const key = `${entry.section}#${entry.chunkIndex}`;
+                const prev = chunkMetaMap.get(key);
+                return !prev || prev.textHash !== entry.hash;
+            })
+            : [];
 
     const chunkStructureChanged = chunkIdsToDelete.length > 0 || existingChunkRows.length !== newChunkEntries.length;
+    const shouldProcessChunks = ENABLE_CHUNK_INDEX
+        ? forceChunkReembed || chunkEmbedsNeeded.length > 0 || chunkIdsToDelete.length > 0 || chunkStructureChanged || chunkMetaRemovals.length > 0
+        : chunkIdsToDelete.length > 0 || existingChunkRows.length > 0 || chunkMetaRemovals.length > 0;
 
-    const shouldProcessChunks = FORCE_REEMBED || chunkEmbedsNeeded.length > 0 || chunkIdsToDelete.length > 0 || chunkStructureChanged;
+    if (!cardNeedsUpdate && !shouldProcessChunks && verifyCardDocs) {
+        const expectedSections = cardSectionEntries.map(entry => entry.section);
+        const hasVectors = await cardDocHasVectors(cardId, expectedSections);
+        if (!hasVectors) {
+            cardNeedsUpdate = true;
+        }
+    }
 
     if (!cardNeedsUpdate && !shouldProcessChunks) {
         stats.skipped += 1;
@@ -494,7 +720,7 @@ async function handleCard(row, db) {
     }
 
     if (cardNeedsUpdate) {
-        const vectors = await embedBatchParallel(cardSectionEntries.map(entry => entry.text));
+        const vectors = await embedTexts(cardSectionEntries.map(entry => entry.text));
         const cardDoc = {
             id: cardId,
             data: dataPayload,
@@ -565,7 +791,7 @@ async function handleCard(row, db) {
     }
 
     if (chunkEmbedsNeeded.length) {
-        const vectors = await embedBatchParallel(chunkEmbedsNeeded.map(entry => entry.text));
+        const vectors = await embedTexts(chunkEmbedsNeeded.map(entry => entry.text));
         const docs = chunkEmbedsNeeded.map((entry, idx) => ({
             id: entry.id,
             card_id: cardId,
@@ -646,8 +872,73 @@ async function handleCard(row, db) {
     }
 }
 
+async function deleteVectorDocs(cardId, db) {
+    try {
+        await meiliDeleteDocuments(CARDS_INDEX, [cardId]);
+    } catch (error) {
+        console.warn(`[WARN] Failed to delete vector card doc ${cardId}: ${error?.message || error}`);
+    }
+
+    try {
+        const chunkIds = db.prepare('SELECT id FROM card_chunk_map WHERE cardId = ?').all(cardId).map(row => row.id);
+        if (chunkIds.length) {
+            await meiliDeleteDocuments(CHUNKS_INDEX, chunkIds);
+        }
+    } catch (error) {
+        console.warn(`[WARN] Failed to delete vector chunk docs for ${cardId}: ${error?.message || error}`);
+    }
+}
+
+async function processRows(rows, db, totalOverride = null) {
+    const total = Number.isFinite(totalOverride) ? totalOverride : rows.length;
+    for (const row of rows) {
+        if (CARD_LIMIT && stats.processed >= CARD_LIMIT) {
+            break;
+        }
+        await handleCard(row, db);
+        stats.processed += 1;
+        if (stats.processed % LOG_EVERY === 0) {
+            console.log(`[INFO] Processed ${stats.processed}/${CARD_LIMIT || total} cards — updated cards: ${stats.cardUpdates}, chunk upserts: ${stats.chunkUpdates}, chunk deletes: ${stats.chunkDeletes}, skipped: ${stats.skipped}`);
+        }
+    }
+}
+
+async function processCardIds(cardIds, db) {
+    const uniqueIds = Array.from(new Set(cardIds.map(id => String(id)).filter(Boolean)));
+    const total = uniqueIds.length;
+    if (!total) return;
+    const chunkSize = 900;
+    const batches = splitArray(uniqueIds, chunkSize);
+    for (const batch of batches) {
+        const placeholders = batch.map(() => '?').join(', ');
+        const rows = db.prepare(
+            `SELECT ${CARD_SELECT_FIELDS} FROM cards WHERE id IN (${placeholders}) ORDER BY id ASC`
+        ).all(...batch);
+        if (rows.length) {
+            await processRows(rows, db, total);
+        }
+    }
+}
+
+function resolveQueueBatchSize() {
+    if (Number.isFinite(QUEUE_BATCH) && QUEUE_BATCH > 0) {
+        return Math.floor(QUEUE_BATCH);
+    }
+    if (Number.isFinite(CARD_LIMIT) && CARD_LIMIT > 0) {
+        return Math.floor(CARD_LIMIT);
+    }
+    return 1000;
+}
+
 async function main() {
-    console.log(`[INFO] Starting vector ETL into ${CARDS_INDEX} / ${CHUNKS_INDEX}`);
+    console.log(`[INFO] Starting vector ETL into ${CARDS_INDEX}${ENABLE_CHUNK_INDEX ? ` / ${CHUNKS_INDEX}` : ' (chunks disabled)'}`);
+
+    await ensureEmbedderSettings(CARDS_INDEX, EMBED_DIMENSIONS);
+    cardsIndexClient = await ensureIndex(CARDS_INDEX, 'id');
+    if (ENABLE_CHUNK_INDEX) {
+        await ensureEmbedderSettings(CHUNKS_INDEX, EMBED_DIMENSIONS);
+        chunksIndexClient = await ensureIndex(CHUNKS_INDEX, 'id');
+    }
 
     // Check for secondary Ollama instance
     if (SECONDARY_OLLAMA_URL) {
@@ -665,15 +956,137 @@ async function main() {
         console.log(`[INFO] No secondary instance configured. Using single instance: ${DEFAULT_OLLAMA_URL}`);
     }
 
-    await initDatabase({ skipSchemaMigrations: true, skipTagRebuild: true, skipTokenBackfill: true });
+    const explicitIds = parseIdList(IDS_FILTER);
+    const deleteIds = parseIdList(DELETE_IDS_FILTER);
+    const queueRowIds = parseIdList(QUEUE_ROW_IDS_FILTER);
+    const needsSchema = QUEUE_MODE || explicitIds.length > 0 || deleteIds.length > 0 || queueRowIds.length > 0;
+
+    await initDatabase({ skipSchemaMigrations: !needsSchema, skipTagRebuild: true, skipTokenBackfill: true });
     const db = getDatabase();
     const totalRow = db.prepare('SELECT COUNT(*) as count FROM cards').get();
     stats.total = totalRow?.count || 0;
 
+    if (QUEUE_MODE) {
+        forceReembedAll = false;
+        forceChunkReembed = false;
+        verifyCardDocs = false;
+
+        const batchSize = resolveQueueBatchSize();
+        const queueRows = db.prepare(
+            'SELECT id, cardId, action FROM vector_index_queue ORDER BY id LIMIT ?'
+        ).all(batchSize);
+
+        if (!queueRows.length) {
+            console.log('[INFO] Vector queue is empty; nothing to do.');
+            process.exit(0);
+        }
+
+        const actionMap = new Map();
+        for (const row of queueRows) {
+            const cardId = String(row.cardId);
+            const action = row.action === 'delete' ? 'delete' : 'upsert';
+            const existing = actionMap.get(cardId);
+            if (!existing || action === 'delete') {
+                actionMap.set(cardId, action);
+            }
+        }
+
+        const queueDeleteIds = [];
+        const queueUpsertIds = [];
+        actionMap.forEach((action, cardId) => {
+            if (action === 'delete') {
+                queueDeleteIds.push(cardId);
+            } else {
+                queueUpsertIds.push(cardId);
+            }
+        });
+
+        stats.total = queueDeleteIds.length + queueUpsertIds.length;
+
+        for (const cardId of queueDeleteIds) {
+            await deleteVectorDocs(cardId, db);
+            stats.processed += 1;
+        }
+
+        if (queueUpsertIds.length) {
+            await processCardIds(queueUpsertIds, db);
+        }
+
+        const queueIds = queueRows.map(row => row.id);
+        const deletePlaceholders = queueIds.map(() => '?').join(', ');
+        db.prepare(`DELETE FROM vector_index_queue WHERE id IN (${deletePlaceholders})`).run(...queueIds);
+
+        console.log('[INFO] Vector ETL (queue) complete:', stats);
+        process.exit(0);
+    }
+
+    if (deleteIds.length) {
+        for (const cardId of deleteIds) {
+            await deleteVectorDocs(cardId, db);
+            stats.processed += 1;
+        }
+    }
+
+    if (!explicitIds.length && deleteIds.length) {
+        if (queueRowIds.length) {
+            const deletePlaceholders = queueRowIds.map(() => '?').join(', ');
+            db.prepare(`DELETE FROM vector_index_queue WHERE id IN (${deletePlaceholders})`).run(...queueRowIds);
+        }
+        console.log('[INFO] Vector ETL (filtered deletes) complete:', stats);
+        process.exit(0);
+    }
+
+    if (explicitIds.length) {
+        forceReembedAll = false;
+        forceChunkReembed = false;
+        verifyCardDocs = false;
+        stats.total = explicitIds.length;
+        await processCardIds(explicitIds, db);
+        if (queueRowIds.length) {
+            const deletePlaceholders = queueRowIds.map(() => '?').join(', ');
+            db.prepare(`DELETE FROM vector_index_queue WHERE id IN (${deletePlaceholders})`).run(...queueRowIds);
+        }
+        console.log('[INFO] Vector ETL (filtered) complete:', stats);
+        process.exit(0);
+    }
+
+    let cardsDocCount = null;
+    let chunksDocCount = null;
+    try {
+        const cardsStats = await cardsIndexClient.getStats();
+        cardsDocCount = typeof cardsStats?.numberOfDocuments === 'number' ? cardsStats.numberOfDocuments : null;
+    } catch (error) {
+        console.warn(`[WARN] Failed to read stats for ${CARDS_INDEX}: ${error?.message || error}`);
+    }
+    if (ENABLE_CHUNK_INDEX && chunksIndexClient) {
+        try {
+            const chunksStats = await chunksIndexClient.getStats();
+            chunksDocCount = typeof chunksStats?.numberOfDocuments === 'number' ? chunksStats.numberOfDocuments : null;
+        } catch (error) {
+            console.warn(`[WARN] Failed to read stats for ${CHUNKS_INDEX}: ${error?.message || error}`);
+        }
+    }
+
+    if (cardsDocCount === 0 && stats.total > 0) {
+        forceReembedAll = true;
+        verifyCardDocs = false;
+        console.warn(`[WARN] ${CARDS_INDEX} is empty; forcing full card re-embed`);
+    } else if (!forceReembedAll && Number.isFinite(cardsDocCount) && cardsDocCount < stats.total) {
+        verifyCardDocs = true;
+        console.warn(`[WARN] ${CARDS_INDEX} has ${cardsDocCount}/${stats.total} docs; verifying per-card vector docs`);
+    }
+
+    if (ENABLE_CHUNK_INDEX && chunksDocCount === 0 && stats.total > 0) {
+        forceChunkReembed = true;
+        console.warn(`[WARN] ${CHUNKS_INDEX} is empty; forcing chunk re-embed`);
+    } else if (!ENABLE_CHUNK_INDEX) {
+        forceChunkReembed = false;
+    }
+
     let lastId = START_AFTER || null;
     while (true) {
         const args = [];
-        let sql = 'SELECT id, name, tagline, description, topics, tokenCount, tokenDescriptionCount, tokenPersonalityCount, tokenScenarioCount, tokenMesExampleCount, tokenFirstMessageCount, tokenSystemPromptCount, tokenPostHistoryCount, author, language, source, sourceId, sourcePath, sourceUrl, visibility, favorited, hasAlternateGreetings, hasLorebook, hasEmbeddedLorebook, hasLinkedLorebook, hasExampleDialogues, hasSystemPrompt, hasGallery, isFuzzed, lastModified, createdAt, nChats, nMessages, n_favorites, starCount, fullPath FROM cards';
+        let sql = `SELECT ${CARD_SELECT_FIELDS} FROM cards`;
         if (lastId !== null && lastId !== undefined) {
             sql += ' WHERE id > ?';
             args.push(lastId);

--- a/scripts/flush-vector-indexes.js
+++ b/scripts/flush-vector-indexes.js
@@ -53,20 +53,22 @@ async function deleteIndexIfExists(client, taskClient, indexUid) {
     }
 }
 
-async function clearChunkMap(skip) {
+async function clearChunkArtifacts(skip) {
     if (skip) {
-        console.log('[INFO] Skipping local card_chunk_map purge');
+        console.log('[INFO] Skipping local chunk artifact purge');
         return;
     }
     await initDatabase({ skipSchemaMigrations: true, skipTagRebuild: true, skipTokenBackfill: true });
     const db = getDatabase();
-    db.prepare('DELETE FROM card_chunk_map').run();
-    console.log('[INFO] Cleared card_chunk_map table');
+    const mapResult = db.prepare('DELETE FROM card_chunk_map').run();
+    const metaResult = db.prepare('DELETE FROM card_embedding_meta WHERE chunk_index >= 0').run();
+    console.log(`[INFO] Cleared chunk artifacts (card_chunk_map=${mapResult.changes || 0}, card_embedding_meta=${metaResult.changes || 0})`);
 }
 
 async function main() {
     const args = new Set(process.argv.slice(2));
     const keepChunks = args.has('--keep-chunks') || process.env.LCR_VECTOR_KEEP_CHUNKS === '1';
+    const chunksOnly = args.has('--chunks-only') || process.env.LCR_VECTOR_CHUNKS_ONLY === '1';
 
     const config = loadConfig();
     const meiliCfg = config?.meilisearch || {};
@@ -92,12 +94,18 @@ async function main() {
 
     const taskClient = client.tasks;
 
-    await deleteIndexIfExists(client, taskClient, cardsIndex);
+    if (!chunksOnly) {
+        await deleteIndexIfExists(client, taskClient, cardsIndex);
+    }
     await deleteIndexIfExists(client, taskClient, chunksIndex);
 
-    await clearChunkMap(keepChunks);
+    await clearChunkArtifacts(keepChunks);
 
-    console.log('[INFO] Vector indexes flushed. Run `npm run vector:backfill` (optionally with LCR_VECTOR_FORCE=1) to rebuild.');
+    if (chunksOnly) {
+        console.log('[INFO] Chunk vector artifacts flushed. Chunk indexing will stay gone until chunk vectors are re-enabled and backfilled.');
+    } else {
+        console.log('[INFO] Vector indexes flushed. Run `npm run vector:backfill` (optionally with LCR_VECTOR_FORCE=1) to rebuild.');
+    }
     process.exit(0);
 }
 

--- a/scripts/optimize-pngs.js
+++ b/scripts/optimize-pngs.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import sharp from 'sharp';
+import extractChunks from 'png-chunks-extract';
+import encodeChunks from 'png-chunks-encode';
+import { initDatabase, getDatabase } from '../backend/database.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.join(__dirname, '..');
+const staticDir = path.join(projectRoot, 'static');
+
+// Configuration from env vars
+const IDS_FILTER = process.env.LCR_OPTIMIZE_IDS || '';
+const QUEUE_ROW_IDS = process.env.LCR_OPTIMIZE_QUEUE_IDS || '';
+const BATCH_LIMIT = Number(process.env.LCR_OPTIMIZE_BATCH || 200);
+const DRY_RUN = process.env.LCR_OPTIMIZE_DRY_RUN === '1';
+const MAX_MEGAPIXELS = Number(process.env.LCR_OPTIMIZE_MAX_MP || 4);
+const COMPRESSION_LEVEL = Number(process.env.LCR_OPTIMIZE_COMPRESSION || 9);
+const ALL_MODE = process.argv.includes('--all');
+const LOG_EVERY = 25;
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+const maxPixels = MAX_MEGAPIXELS * 1_000_000;
+
+const stats = {
+    processed: 0,
+    optimized: 0,
+    skippedSmall: 0,
+    skippedNotPng: 0,
+    skippedMissing: 0,
+    skippedNonPng: 0,
+    errors: 0,
+    savedBytes: 0
+};
+
+function getCardFilePath(cardId) {
+    const cardIdStr = String(cardId);
+    if (!/^\d+$/.test(cardIdStr)) return null;
+    const subfolder = path.join(staticDir, cardIdStr.substring(0, 2));
+    return path.join(subfolder, `${cardIdStr}.png`);
+}
+
+function isPng(buffer) {
+    return buffer.length >= PNG_SIGNATURE.length
+        && buffer.slice(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+}
+
+function extractTextChunks(chunks) {
+    const textChunks = [];
+    for (const chunk of chunks) {
+        if (chunk.name === 'tEXt' || chunk.name === 'zTXt' || chunk.name === 'iTXt') {
+            textChunks.push(chunk);
+        }
+    }
+    return textChunks;
+}
+
+function reEmbedTextChunks(optimizedBuffer, textChunks) {
+    if (!textChunks.length) return optimizedBuffer;
+
+    const chunks = extractChunks(optimizedBuffer);
+
+    // Find IEND position
+    const iendIndex = chunks.findIndex(c => c.name === 'IEND');
+    if (iendIndex <= 0) return optimizedBuffer;
+
+    // Insert text chunks before IEND
+    for (let i = textChunks.length - 1; i >= 0; i--) {
+        chunks.splice(iendIndex, 0, textChunks[i]);
+    }
+
+    return Buffer.from(encodeChunks(chunks));
+}
+
+async function optimizeCard(cardId) {
+    const pngPath = getCardFilePath(cardId);
+    if (!pngPath) {
+        stats.errors++;
+        return;
+    }
+
+    if (!fs.existsSync(pngPath)) {
+        stats.skippedMissing++;
+        return;
+    }
+
+    const originalBuffer = fs.readFileSync(pngPath);
+
+    if (!isPng(originalBuffer)) {
+        stats.skippedNonPng++;
+        return;
+    }
+
+    // Extract all text chunks before processing
+    let textChunks;
+    try {
+        const chunks = extractChunks(originalBuffer);
+        textChunks = extractTextChunks(chunks);
+    } catch (error) {
+        console.error(`[ERROR] Failed to extract chunks from card ${cardId}: ${error.message}`);
+        stats.errors++;
+        return;
+    }
+
+    // Get dimensions
+    let metadata;
+    try {
+        metadata = await sharp(originalBuffer).metadata();
+    } catch (error) {
+        console.error(`[ERROR] Failed to read metadata for card ${cardId}: ${error.message}`);
+        stats.errors++;
+        return;
+    }
+
+    const { width, height } = metadata;
+    const currentPixels = width * height;
+
+    if (currentPixels <= maxPixels) {
+        stats.skippedSmall++;
+        return;
+    }
+
+    if (DRY_RUN) {
+        const ratio = Math.sqrt(maxPixels / currentPixels);
+        const newW = Math.round(width * ratio);
+        const newH = Math.round(height * ratio);
+        console.log(`[DRY-RUN] Card ${cardId}: ${width}x${height} (${(currentPixels / 1e6).toFixed(1)}MP) -> ${newW}x${newH}`);
+        stats.optimized++;
+        return;
+    }
+
+    try {
+        // Calculate target dimensions preserving aspect ratio
+        const ratio = Math.sqrt(maxPixels / currentPixels);
+        const targetWidth = Math.round(width * ratio);
+        const targetHeight = Math.round(height * ratio);
+
+        // Resize and compress
+        let optimizedBuffer = await sharp(originalBuffer)
+            .resize(targetWidth, targetHeight, { fit: 'inside' })
+            .png({ compressionLevel: COMPRESSION_LEVEL, adaptiveFiltering: true })
+            .toBuffer();
+
+        // Re-embed text chunks (especially the chara metadata)
+        optimizedBuffer = reEmbedTextChunks(optimizedBuffer, textChunks);
+
+        const savedBytes = originalBuffer.length - optimizedBuffer.length;
+
+        fs.writeFileSync(pngPath, optimizedBuffer);
+
+        stats.optimized++;
+        stats.savedBytes += savedBytes;
+
+        if (stats.optimized % LOG_EVERY === 0 || stats.optimized === 1) {
+            console.log(
+                `[INFO] Optimized card ${cardId}: ${width}x${height} -> ${targetWidth}x${targetHeight}, ` +
+                `saved ${(savedBytes / 1024).toFixed(0)}KB`
+            );
+        }
+    } catch (error) {
+        console.error(`[ERROR] Failed to optimize card ${cardId}: ${error.message}`);
+        stats.errors++;
+    }
+}
+
+async function main() {
+    console.log('[INFO] PNG Optimization starting...');
+    console.log(`[INFO] Config: maxMP=${MAX_MEGAPIXELS}, compression=${COMPRESSION_LEVEL}, dryRun=${DRY_RUN}`);
+
+    initDatabase();
+    const db = getDatabase();
+
+    let cardIds = [];
+
+    if (IDS_FILTER) {
+        // Queue-driven mode: process specific IDs from the service
+        cardIds = IDS_FILTER.split(',').filter(Boolean).map(Number);
+        console.log(`[INFO] Queue mode: processing ${cardIds.length} cards`);
+    } else if (ALL_MODE) {
+        // Full backlog mode: process all non-risuai cards
+        const rows = db.prepare(
+            "SELECT id FROM cards WHERE source != 'risuai' ORDER BY id"
+        ).all();
+        cardIds = rows.map(r => r.id);
+        console.log(`[INFO] Full backlog mode: ${cardIds.length} non-RisuAI cards to check`);
+    } else {
+        // Default: drain from queue table
+        const rows = db.prepare(
+            'SELECT cardId FROM png_optimization_queue ORDER BY id LIMIT ?'
+        ).all(BATCH_LIMIT);
+        cardIds = rows.map(r => r.cardId);
+        console.log(`[INFO] Queue drain mode: ${cardIds.length} cards from queue`);
+    }
+
+    if (!cardIds.length) {
+        console.log('[INFO] No cards to process. Exiting.');
+        process.exit(0);
+    }
+
+    for (const cardId of cardIds) {
+        await optimizeCard(cardId);
+        stats.processed++;
+
+        if (stats.processed % LOG_EVERY === 0) {
+            console.log(
+                `[INFO] Progress: ${stats.processed}/${cardIds.length} ` +
+                `(optimized=${stats.optimized}, skippedSmall=${stats.skippedSmall}, errors=${stats.errors})`
+            );
+        }
+    }
+
+    // Clean up queue rows if we were given specific queue row IDs
+    const queueRowIds = QUEUE_ROW_IDS.split(',').filter(Boolean).map(Number);
+    if (queueRowIds.length > 0) {
+        try {
+            const placeholders = queueRowIds.map(() => '?').join(',');
+            db.prepare(`DELETE FROM png_optimization_queue WHERE id IN (${placeholders})`).run(...queueRowIds);
+            console.log(`[INFO] Cleaned ${queueRowIds.length} rows from png_optimization_queue`);
+        } catch (error) {
+            console.error(`[ERROR] Failed to clean queue: ${error.message}`);
+        }
+    } else if (!IDS_FILTER && !ALL_MODE && cardIds.length > 0) {
+        // Queue drain mode without explicit row IDs — delete by cardId
+        try {
+            const placeholders = cardIds.map(() => '?').join(',');
+            db.prepare(`DELETE FROM png_optimization_queue WHERE cardId IN (${placeholders})`).run(...cardIds);
+            console.log(`[INFO] Cleaned ${cardIds.length} processed cards from png_optimization_queue`);
+        } catch (error) {
+            console.error(`[ERROR] Failed to clean queue: ${error.message}`);
+        }
+    }
+
+    const savedMB = (stats.savedBytes / (1024 * 1024)).toFixed(1);
+    console.log(`[INFO] PNG Optimization complete:`);
+    console.log(`  Processed: ${stats.processed}`);
+    console.log(`  Optimized: ${stats.optimized}`);
+    console.log(`  Skipped (already small): ${stats.skippedSmall}`);
+    console.log(`  Skipped (missing): ${stats.skippedMissing}`);
+    console.log(`  Skipped (not PNG): ${stats.skippedNonPng}`);
+    console.log(`  Errors: ${stats.errors}`);
+    console.log(`  Space saved: ${savedMB}MB`);
+
+    process.exit(stats.errors > 0 ? 1 : 0);
+}
+
+main().catch(error => {
+    console.error('[FATAL]', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a real `vectorSearch.enableChunks` toggle for optional `card_chunks` usage
- make search/indexing/embedder scripts honor that toggle and support clean chunk-only cleanup
- update Meilisearch docs/compose notes to reflect the current setup

## Included
- backend cleanup path when chunk vectors are disabled
- cards-only vector search support when chunks are off
- chunk-aware maintenance script updates
- README and Docker README updates
- compose updates for the current Meilisearch runtime

## Not Included
- no local config/runtime files such as `config.json`, `config.js`, `.env`, DB files, or snapshot/data directories

## Verification
- `node --check` passed for changed backend/services/scripts files
- frontend build was previously validated in the main workspace before the clean branch was cut

## Notes
- branch was prepared from a clean worktree to avoid unrelated local changes
- draft PR intentionally left open for further testing before merge
